### PR TITLE
Fix return of crypto.Signature.sign{Hex,String}.

### DIFF
--- a/crypto-1.1.js
+++ b/crypto-1.1.js
@@ -854,11 +854,11 @@ KJUR.crypto.Signature = function(params) {
 	    };
 	    this.signString = function(str) {
 		this.updateString(str);
-		this.sign();
+		return this.sign();
 	    };
 	    this.signHex = function(hex) {
 		this.updateHex(hex);
-		this.sign();
+		return this.sign();
 	    };
 	    this.verify = function(hSigVal) {
 	        this.sHashHex = this.md.digest();


### PR DESCRIPTION
Small bugfix: signString and signHex should return the signatures generated by crypto.Signature.sign.
