### PR TITLE
define variable `KJUR` before use

### DIFF
--- a/asn1-1.0.js
+++ b/asn1-1.0.js
@@ -36,6 +36,7 @@
  * @name KJUR
  * @namespace kjur's class library name space
  */
+var KJUR;
 if (typeof KJUR == "undefined" || !KJUR) KJUR = {};
 
 /**


### PR DESCRIPTION
In an `use strict` environment the javascript runtime would fail with the following error:

```
ReferenceError: KJUR is not defined
```

For more information see: http://www.w3schools.com/js/js_strict.asp

In our case https://babeljs.io/ introduces a `use strict` header in each file which goes through babelify during the build process.

Please merge this PR and update the npm version of jsrsasign. 

Tough, we're just using a small portion of the lib it's key to us. Let us know if you need any further help. We would be glad to help out. 
