### PR TITLE
Some cleanup of crypto-1.1.js and keyutil-1.0.js fles

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,87 @@
+{
+    // JSHint Default Configuration File (as on JSHint website)
+    // See http://jshint.com/docs/ for more details
+
+    "maxerr"        : 5000,     // {int} Maximum error before stopping
+
+    // Enforcing
+    "bitwise"       : true,     // true: Prohibit bitwise operators (&, |, ^, etc.)
+    "camelcase"     : false,    // true: Identifiers must be in camelCase
+    "curly"         : true,     // true: Require {} for every new block or scope
+    "eqeqeq"        : true,     // true: Require triple equals (===) for comparison
+    "forin"         : true,     // true: Require filtering for..in loops with obj.hasOwnProperty()
+    "freeze"        : true,     // true: prohibits overwriting prototypes of native objects such as Array, Date etc.
+    "immed"         : false,    // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
+    "indent"        : 4,        // {int} Number of spaces to use for indentation
+    "latedef"       : false,    // true: Require variables/functions to be defined before being used
+    "newcap"        : false,    // true: Require capitalization of all constructor functions e.g. `new F()`
+    "noarg"         : true,     // true: Prohibit use of `arguments.caller` and `arguments.callee`
+    "noempty"       : true,     // true: Prohibit use of empty blocks
+    "nonbsp"        : true,     // true: Prohibit "non-breaking whitespace" characters.
+    "nonew"         : false,    // true: Prohibit use of constructors for side-effects (without assignment)
+    "plusplus"      : false,    // true: Prohibit use of `++` & `--`
+    "quotmark"      : false,    // Quotation mark consistency:
+                                //   false    : do nothing (default)
+                                //   true     : ensure whatever is used is consistent
+                                //   "single" : require single quotes
+                                //   "double" : require double quotes
+    "undef"         : true,     // true: Require all non-global variables to be declared (prevents global leaks)
+    "unused"        : true,     // true: Require all defined variables be used
+    "strict"        : true,     // true: Requires all functions run in ES5 Strict Mode
+    "maxparams"     : false,    // {int} Max number of formal params allowed per function
+    "maxdepth"      : false,    // {int} Max depth of nested blocks (within functions)
+    "maxstatements" : false,    // {int} Max number statements per function
+    "maxcomplexity" : false,    // {int} Max cyclomatic complexity per function
+    "maxlen"        : false,    // {int} Max number of characters per line
+
+    // Relaxing
+    "asi"           : false,     // true: Tolerate Automatic Semicolon Insertion (no semicolons)
+    "boss"          : false,     // true: Tolerate assignments where comparisons would be expected
+    "debug"         : false,     // true: Allow debugger statements e.g. browser breakpoints.
+    "eqnull"        : false,     // true: Tolerate use of `== null`
+    "es5"           : false,     // true: Allow ES5 syntax (ex: getters and setters)
+    "esnext"        : false,     // true: Allow ES.next (ES6) syntax (ex: `const`)
+    "moz"           : false,     // true: Allow Mozilla specific syntax (extends and overrides esnext features)
+                                 // (ex: `for each`, multiple try/catch, function expression…)
+    "evil"          : false,     // true: Tolerate use of `eval` and `new Function()`
+    "expr"          : false,     // true: Tolerate `ExpressionStatement` as Programs
+    "funcscope"     : false,     // true: Tolerate defining variables inside control statements
+    "globalstrict"  : true,      // true: Allow global "use strict" (also enables 'strict')
+    "iterator"      : false,     // true: Tolerate using the `__iterator__` property
+    "lastsemic"     : false,     // true: Tolerate omitting a semicolon for the last statement of a 1-line block
+    "laxbreak"      : false,     // true: Tolerate possibly unsafe line breakings
+    "laxcomma"      : false,     // true: Tolerate comma-first style coding
+    "loopfunc"      : false,     // true: Tolerate functions being defined in loops
+    "multistr"      : false,     // true: Tolerate multi-line strings
+    "noyield"       : false,     // true: Tolerate generator functions with no yield statement in them.
+    "notypeof"      : false,     // true: Tolerate invalid typeof operator values
+    "proto"         : false,     // true: Tolerate using the `__proto__` property
+    "scripturl"     : false,     // true: Tolerate script-targeted URLs
+    "shadow"        : false,     // true: Allows re-define variables later in code e.g. `var x=1; x=2;`
+    "sub"           : false,     // true: Tolerate using `[]` notation when it can still be expressed in dot notation
+    "supernew"      : false,     // true: Tolerate `new function () { ... };` and `new Object;`
+    "validthis"     : false,     // true: Tolerate using this in a non-constructor function
+
+    // Environments
+    "browser"       : true,     // Web Browser (window, document, etc)
+    "browserify"    : false,    // Browserify (node.js code in the browser)
+    "couch"         : false,    // CouchDB
+    "devel"         : true,     // Development/debugging (alert, confirm, etc)
+    "dojo"          : false,    // Dojo Toolkit
+    "jasmine"       : false,    // Jasmine
+    "jquery"        : false,    // jQuery
+    "mocha"         : true,     // Mocha
+    "mootools"      : false,    // MooTools
+    "node"          : false,    // Node.js
+    "nonstandard"   : false,    // Widely adopted globals (escape, unescape, etc)
+    "prototypejs"   : false,    // Prototype and Scriptaculous
+    "qunit"         : false,    // QUnit
+    "rhino"         : false,    // Rhino
+    "shelljs"       : false,    // ShellJS
+    "worker"        : false,    // Web Workers
+    "wsh"           : false,    // Windows Scripting Host
+    "yui"           : false,    // Yahoo User Interface
+
+    // Custom Globals
+    "globals"       : {}        // additional predefined global variables
+}

--- a/crypto-1.1.js
+++ b/crypto-1.1.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*! crypto-1.1.5.js (c) 2013 Kenji Urushima | kjur.github.com/jsrsasign/license
  */
 /*
@@ -8,7 +10,7 @@
  * This software is licensed under the terms of the MIT License.
  * http://kjur.github.com/jsrsasign/license
  *
- * The above copyright and license notice shall be 
+ * The above copyright and license notice shall be
  * included in all copies or substantial portions of the Software.
  */
 
@@ -21,12 +23,14 @@
  * @license <a href="http://kjur.github.io/jsrsasign/license/">MIT License</a>
  */
 
-/** 
+/**
  * kjur's class library name space
  * @name KJUR
  * @namespace kjur's class library name space
  */
-if (typeof KJUR == "undefined" || !KJUR) KJUR = {};
+if (typeof KJUR === "undefined" || !KJUR) {
+    var KJUR = {};
+}
 /**
  * kjur's cryptographic algorithm provider library name space
  * <p>
@@ -41,7 +45,9 @@ if (typeof KJUR == "undefined" || !KJUR) KJUR = {};
  * @name KJUR.crypto
  * @namespace
  */
-if (typeof KJUR.crypto == "undefined" || !KJUR.crypto) KJUR.crypto = {};
+if (typeof KJUR.crypto === "undefined" || !KJUR.crypto) {
+    KJUR.crypto = {};
+}
 
 /**
  * static object for cryptographic function utilities
@@ -51,78 +57,78 @@ if (typeof KJUR.crypto == "undefined" || !KJUR.crypto) KJUR.crypto = {};
  * @property {Array} DEFAULTPROVIDER associative array of default provider name for each hash and signature algorithms
  * @description
  */
-KJUR.crypto.Util = new function() {
-    this.DIGESTINFOHEAD = {
-	'sha1':      "3021300906052b0e03021a05000414",
-        'sha224':    "302d300d06096086480165030402040500041c",
-	'sha256':    "3031300d060960864801650304020105000420",
-	'sha384':    "3041300d060960864801650304020205000430",
-	'sha512':    "3051300d060960864801650304020305000440",
-	'md2':       "3020300c06082a864886f70d020205000410",
-	'md5':       "3020300c06082a864886f70d020505000410",
-	'ripemd160': "3021300906052b2403020105000414",
-    };
+KJUR.crypto.Util = {
+    DIGESTINFOHEAD: {
+        'sha1': "3021300906052b0e03021a05000414",
+        'sha224': "302d300d06096086480165030402040500041c",
+        'sha256': "3031300d060960864801650304020105000420",
+        'sha384': "3041300d060960864801650304020205000430",
+        'sha512': "3051300d060960864801650304020305000440",
+        'md2': "3020300c06082a864886f70d020205000410",
+        'md5': "3020300c06082a864886f70d020505000410",
+        'ripemd160': "3021300906052b2403020105000414",
+    },
 
     /*
      * @since crypto 1.1.1
      */
-    this.DEFAULTPROVIDER = {
-	'md5':			'cryptojs',
-	'sha1':			'cryptojs',
-	'sha224':		'cryptojs',
-	'sha256':		'cryptojs',
-	'sha384':		'cryptojs',
-	'sha512':		'cryptojs',
-	'ripemd160':		'cryptojs',
-	'hmacmd5':		'cryptojs',
-	'hmacsha1':		'cryptojs',
-	'hmacsha224':		'cryptojs',
-	'hmacsha256':		'cryptojs',
-	'hmacsha384':		'cryptojs',
-	'hmacsha512':		'cryptojs',
-	'hmacripemd160':	'cryptojs',
+    DEFAULTPROVIDER: {
+        'md5': 'cryptojs',
+        'sha1': 'cryptojs',
+        'sha224': 'cryptojs',
+        'sha256': 'cryptojs',
+        'sha384': 'cryptojs',
+        'sha512': 'cryptojs',
+        'ripemd160': 'cryptojs',
+        'hmacmd5': 'cryptojs',
+        'hmacsha1': 'cryptojs',
+        'hmacsha224': 'cryptojs',
+        'hmacsha256': 'cryptojs',
+        'hmacsha384': 'cryptojs',
+        'hmacsha512': 'cryptojs',
+        'hmacripemd160': 'cryptojs',
 
-	'MD5withRSA':		'cryptojs/jsrsa',
-	'SHA1withRSA':		'cryptojs/jsrsa',
-	'SHA224withRSA':	'cryptojs/jsrsa',
-	'SHA256withRSA':	'cryptojs/jsrsa',
-	'SHA384withRSA':	'cryptojs/jsrsa',
-	'SHA512withRSA':	'cryptojs/jsrsa',
-	'RIPEMD160withRSA':	'cryptojs/jsrsa',
+        'MD5withRSA': 'cryptojs/jsrsa',
+        'SHA1withRSA': 'cryptojs/jsrsa',
+        'SHA224withRSA': 'cryptojs/jsrsa',
+        'SHA256withRSA': 'cryptojs/jsrsa',
+        'SHA384withRSA': 'cryptojs/jsrsa',
+        'SHA512withRSA': 'cryptojs/jsrsa',
+        'RIPEMD160withRSA': 'cryptojs/jsrsa',
 
-	'MD5withECDSA':		'cryptojs/jsrsa',
-	'SHA1withECDSA':	'cryptojs/jsrsa',
-	'SHA224withECDSA':	'cryptojs/jsrsa',
-	'SHA256withECDSA':	'cryptojs/jsrsa',
-	'SHA384withECDSA':	'cryptojs/jsrsa',
-	'SHA512withECDSA':	'cryptojs/jsrsa',
-	'RIPEMD160withECDSA':	'cryptojs/jsrsa',
+        'MD5withECDSA': 'cryptojs/jsrsa',
+        'SHA1withECDSA': 'cryptojs/jsrsa',
+        'SHA224withECDSA': 'cryptojs/jsrsa',
+        'SHA256withECDSA': 'cryptojs/jsrsa',
+        'SHA384withECDSA': 'cryptojs/jsrsa',
+        'SHA512withECDSA': 'cryptojs/jsrsa',
+        'RIPEMD160withECDSA': 'cryptojs/jsrsa',
 
-	'SHA1withDSA':		'cryptojs/jsrsa',
-	'SHA224withDSA':	'cryptojs/jsrsa',
-	'SHA256withDSA':	'cryptojs/jsrsa',
+        'SHA1withDSA': 'cryptojs/jsrsa',
+        'SHA224withDSA': 'cryptojs/jsrsa',
+        'SHA256withDSA': 'cryptojs/jsrsa',
 
-	'MD5withRSAandMGF1':		'cryptojs/jsrsa',
-	'SHA1withRSAandMGF1':		'cryptojs/jsrsa',
-	'SHA224withRSAandMGF1':		'cryptojs/jsrsa',
-	'SHA256withRSAandMGF1':		'cryptojs/jsrsa',
-	'SHA384withRSAandMGF1':		'cryptojs/jsrsa',
-	'SHA512withRSAandMGF1':		'cryptojs/jsrsa',
-	'RIPEMD160withRSAandMGF1':	'cryptojs/jsrsa',
-    };
+        'MD5withRSAandMGF1': 'cryptojs/jsrsa',
+        'SHA1withRSAandMGF1': 'cryptojs/jsrsa',
+        'SHA224withRSAandMGF1': 'cryptojs/jsrsa',
+        'SHA256withRSAandMGF1': 'cryptojs/jsrsa',
+        'SHA384withRSAandMGF1': 'cryptojs/jsrsa',
+        'SHA512withRSAandMGF1': 'cryptojs/jsrsa',
+        'RIPEMD160withRSAandMGF1': 'cryptojs/jsrsa',
+    },
 
     /*
      * @since crypto 1.1.2
      */
-    this.CRYPTOJSMESSAGEDIGESTNAME = {
-	'md5':		'CryptoJS.algo.MD5',
-	'sha1':		'CryptoJS.algo.SHA1',
-	'sha224':	'CryptoJS.algo.SHA224',
-	'sha256':	'CryptoJS.algo.SHA256',
-	'sha384':	'CryptoJS.algo.SHA384',
-	'sha512':	'CryptoJS.algo.SHA512',
-	'ripemd160':	'CryptoJS.algo.RIPEMD160'
-    };
+    CRYPTOJSMESSAGEDIGESTNAME: {
+        'md5': CryptoJS.algo.MD5,
+        'sha1': CryptoJS.algo.SHA1,
+        'sha224': CryptoJS.algo.SHA224,
+        'sha256': CryptoJS.algo.SHA256,
+        'sha384': CryptoJS.algo.SHA384,
+        'sha512': CryptoJS.algo.SHA512,
+        'ripemd160': CryptoJS.algo.RIPEMD160
+    },
 
     /**
      * get hexadecimal DigestInfo
@@ -133,11 +139,12 @@ KJUR.crypto.Util = new function() {
      * @param {String} alg hash algorithm name (ex. 'sha1')
      * @return {String} hexadecimal string DigestInfo ASN.1 structure
      */
-    this.getDigestInfoHex = function(hHash, alg) {
-	if (typeof this.DIGESTINFOHEAD[alg] == "undefined")
-	    throw "alg not supported in Util.DIGESTINFOHEAD: " + alg;
-	return this.DIGESTINFOHEAD[alg] + hHash;
-    };
+    getDigestInfoHex: function(hHash, alg) {
+        if (typeof this.DIGESTINFOHEAD[alg] === "undefined") {
+            throw "alg not supported in Util.DIGESTINFOHEAD: " + alg;
+        }
+        return this.DIGESTINFOHEAD[alg] + hHash;
+    },
 
     /**
      * get PKCS#1 padded hexadecimal DigestInfo
@@ -149,23 +156,25 @@ KJUR.crypto.Util = new function() {
      * @param {Integer} keySize key bit length (ex. 1024)
      * @return {String} hexadecimal string of PKCS#1 padded DigestInfo
      */
-    this.getPaddedDigestInfoHex = function(hHash, alg, keySize) {
-	var hDigestInfo = this.getDigestInfoHex(hHash, alg);
-	var pmStrLen = keySize / 4; // minimum PM length
+    getPaddedDigestInfoHex: function(hHash, alg, keySize) {
+        var hDigestInfo = this.getDigestInfoHex(hHash, alg);
+        var pmStrLen = keySize / 4; // minimum PM length
 
-	if (hDigestInfo.length + 22 > pmStrLen) // len(0001+ff(*8)+00+hDigestInfo)=22
-	    throw "key is too short for SigAlg: keylen=" + keySize + "," + alg;
+        if ( // len(0001+ff(*8)+00+hDigestInfo)=22
+            hDigestInfo.length + 22 > pmStrLen) {
+            throw "key is too short for SigAlg: keylen=" + keySize + "," + alg;
+        }
 
-	var hHead = "0001";
-	var hTail = "00" + hDigestInfo;
-	var hMid = "";
-	var fLen = pmStrLen - hHead.length - hTail.length;
-	for (var i = 0; i < fLen; i += 2) {
-	    hMid += "ff";
-	}
-	var hPaddedMessage = hHead + hMid + hTail;
-	return hPaddedMessage;
-    };
+        var hHead = "0001";
+        var hTail = "00" + hDigestInfo;
+        var hMid = "";
+        var fLen = pmStrLen - hHead.length - hTail.length;
+        for (var i = 0; i < fLen; i += 2) {
+            hMid += "ff";
+        }
+        var hPaddedMessage = hHead + hMid + hTail;
+        return hPaddedMessage;
+    },
 
     /**
      * get hexadecimal hash of string with specified algorithm
@@ -177,10 +186,12 @@ KJUR.crypto.Util = new function() {
      * @return {String} hexadecimal string of hash value
      * @since 1.1.1
      */
-    this.hashString = function(s, alg) {
-        var md = new KJUR.crypto.MessageDigest({'alg': alg});
+    hashString: function(s, alg) {
+        var md = new KJUR.crypto.MessageDigest({
+            'alg': alg
+        });
         return md.digestString(s);
-    };
+    },
 
     /**
      * get hexadecimal hash of hexadecimal string with specified algorithm
@@ -192,10 +203,12 @@ KJUR.crypto.Util = new function() {
      * @return {String} hexadecimal string of hash value
      * @since 1.1.1
      */
-    this.hashHex = function(sHex, alg) {
-        var md = new KJUR.crypto.MessageDigest({'alg': alg});
+    hashHex: function(sHex, alg) {
+        var md = new KJUR.crypto.MessageDigest({
+            'alg': alg
+        });
         return md.digestHex(sHex);
-    };
+    },
 
     /**
      * get hexadecimal SHA1 hash of string
@@ -206,10 +219,13 @@ KJUR.crypto.Util = new function() {
      * @return {String} hexadecimal string of hash value
      * @since 1.0.3
      */
-    this.sha1 = function(s) {
-        var md = new KJUR.crypto.MessageDigest({'alg':'sha1', 'prov':'cryptojs'});
+    sha1: function(s) {
+        var md = new KJUR.crypto.MessageDigest({
+            'alg': 'sha1',
+            'prov': 'cryptojs'
+        });
         return md.digestString(s);
-    };
+    },
 
     /**
      * get hexadecimal SHA256 hash of string
@@ -220,15 +236,21 @@ KJUR.crypto.Util = new function() {
      * @return {String} hexadecimal string of hash value
      * @since 1.0.3
      */
-    this.sha256 = function(s) {
-        var md = new KJUR.crypto.MessageDigest({'alg':'sha256', 'prov':'cryptojs'});
+    sha256: function(s) {
+        var md = new KJUR.crypto.MessageDigest({
+            'alg': 'sha256',
+            'prov': 'cryptojs'
+        });
         return md.digestString(s);
-    };
+    },
 
-    this.sha256Hex = function(s) {
-        var md = new KJUR.crypto.MessageDigest({'alg':'sha256', 'prov':'cryptojs'});
+    sha256Hex: function(s) {
+        var md = new KJUR.crypto.MessageDigest({
+            'alg': 'sha256',
+            'prov': 'cryptojs'
+        });
         return md.digestHex(s);
-    };
+    },
 
     /**
      * get hexadecimal SHA512 hash of string
@@ -239,15 +261,21 @@ KJUR.crypto.Util = new function() {
      * @return {String} hexadecimal string of hash value
      * @since 1.0.3
      */
-    this.sha512 = function(s) {
-        var md = new KJUR.crypto.MessageDigest({'alg':'sha512', 'prov':'cryptojs'});
+    sha512: function(s) {
+        var md = new KJUR.crypto.MessageDigest({
+            'alg': 'sha512',
+            'prov': 'cryptojs'
+        });
         return md.digestString(s);
-    };
+    },
 
-    this.sha512Hex = function(s) {
-        var md = new KJUR.crypto.MessageDigest({'alg':'sha512', 'prov':'cryptojs'});
+    sha512Hex: function(s) {
+        var md = new KJUR.crypto.MessageDigest({
+            'alg': 'sha512',
+            'prov': 'cryptojs'
+        });
         return md.digestHex(s);
-    };
+    },
 
     /**
      * get hexadecimal MD5 hash of string
@@ -258,10 +286,13 @@ KJUR.crypto.Util = new function() {
      * @return {String} hexadecimal string of hash value
      * @since 1.0.3
      */
-    this.md5 = function(s) {
-        var md = new KJUR.crypto.MessageDigest({'alg':'md5', 'prov':'cryptojs'});
+    md5: function(s) {
+        var md = new KJUR.crypto.MessageDigest({
+            'alg': 'md5',
+            'prov': 'cryptojs'
+        });
         return md.digestString(s);
-    };
+    },
 
     /**
      * get hexadecimal RIPEMD160 hash of string
@@ -272,17 +303,13 @@ KJUR.crypto.Util = new function() {
      * @return {String} hexadecimal string of hash value
      * @since 1.0.3
      */
-    this.ripemd160 = function(s) {
-        var md = new KJUR.crypto.MessageDigest({'alg':'ripemd160', 'prov':'cryptojs'});
+    ripemd160: function(s) {
+        var md = new KJUR.crypto.MessageDigest({
+            'alg': 'ripemd160',
+            'prov': 'cryptojs'
+        });
         return md.digestString(s);
-    };
-
-    /*
-     * @since 1.1.2
-     */
-    this.getCryptoJSMDByName = function(s) {
-	
-    };
+    }
 };
 
 /**
@@ -320,10 +347,6 @@ KJUR.crypto.Util = new function() {
  * var mdHex = md.digest()
  */
 KJUR.crypto.MessageDigest = function(params) {
-    var md = null;
-    var algName = null;
-    var provName = null;
-
     /**
      * set hash algorithm and provider
      * @name setAlgAndProvider
@@ -339,63 +362,65 @@ KJUR.crypto.MessageDigest = function(params) {
      * md.setAlgAndProvider('ripemd160', 'cryptojs');
      */
     this.setAlgAndProvider = function(alg, prov) {
-	if (alg != null && prov === undefined) prov = KJUR.crypto.Util.DEFAULTPROVIDER[alg];
+        if (alg !== null && prov === undefined) {
+            prov = KJUR.crypto.Util.DEFAULTPROVIDER[alg];
+        }
 
-	// for cryptojs
-	if (':md5:sha1:sha224:sha256:sha384:sha512:ripemd160:'.indexOf(alg) != -1 &&
-	    prov == 'cryptojs') {
-	    try {
-		this.md = eval(KJUR.crypto.Util.CRYPTOJSMESSAGEDIGESTNAME[alg]).create();
-	    } catch (ex) {
-		throw "setAlgAndProvider hash alg set fail alg=" + alg + "/" + ex;
-	    }
-	    this.updateString = function(str) {
-		this.md.update(str);
-	    };
-	    this.updateHex = function(hex) {
-		var wHex = CryptoJS.enc.Hex.parse(hex);
-		this.md.update(wHex);
-	    };
-	    this.digest = function() {
-		var hash = this.md.finalize();
-		return hash.toString(CryptoJS.enc.Hex);
-	    };
-	    this.digestString = function(str) {
-		this.updateString(str);
-		return this.digest();
-	    };
-	    this.digestHex = function(hex) {
-		this.updateHex(hex);
-		return this.digest();
-	    };
-	}
-	if (':sha256:'.indexOf(alg) != -1 &&
-	    prov == 'sjcl') {
-	    try {
-		this.md = new sjcl.hash.sha256();
-	    } catch (ex) {
-		throw "setAlgAndProvider hash alg set fail alg=" + alg + "/" + ex;
-	    }
-	    this.updateString = function(str) {
-		this.md.update(str);
-	    };
-	    this.updateHex = function(hex) {
-		var baHex = sjcl.codec.hex.toBits(hex);
-		this.md.update(baHex);
-	    };
-	    this.digest = function() {
-		var hash = this.md.finalize();
-		return sjcl.codec.hex.fromBits(hash);
-	    };
-	    this.digestString = function(str) {
-		this.updateString(str);
-		return this.digest();
-	    };
-	    this.digestHex = function(hex) {
-		this.updateHex(hex);
-		return this.digest();
-	    };
-	}
+        // for cryptojs
+        if (':md5:sha1:sha224:sha256:sha384:sha512:ripemd160:'.indexOf(alg) !== -1 &&
+            prov === 'cryptojs') {
+            try {
+                this.md = KJUR.crypto.Util.CRYPTOJSMESSAGEDIGESTNAME[alg].create();
+            } catch (ex) {
+                throw "setAlgAndProvider hash alg set fail alg=" + alg + "/" + ex;
+            }
+            this.updateString = function(str) {
+                this.md.update(str);
+            };
+            this.updateHex = function(hex) {
+                var wHex = CryptoJS.enc.Hex.parse(hex);
+                this.md.update(wHex);
+            };
+            this.digest = function() {
+                var hash = this.md.finalize();
+                return hash.toString(CryptoJS.enc.Hex);
+            };
+            this.digestString = function(str) {
+                this.updateString(str);
+                return this.digest();
+            };
+            this.digestHex = function(hex) {
+                this.updateHex(hex);
+                return this.digest();
+            };
+        }
+        if (':sha256:'.indexOf(alg) !== -1 &&
+            prov === 'sjcl') {
+            try {
+                this.md = new sjcl.hash.sha256();
+            } catch (ex) {
+                throw "setAlgAndProvider hash alg set fail alg=" + alg + "/" + ex;
+            }
+            this.updateString = function(str) {
+                this.md.update(str);
+            };
+            this.updateHex = function(hex) {
+                var baHex = sjcl.codec.hex.toBits(hex);
+                this.md.update(baHex);
+            };
+            this.digest = function() {
+                var hash = this.md.finalize();
+                return sjcl.codec.hex.fromBits(hash);
+            };
+            this.digestString = function(str) {
+                this.updateString(str);
+                return this.digest();
+            };
+            this.digestHex = function(hex) {
+                this.updateHex(hex);
+                return this.digest();
+            };
+        }
     };
 
     /**
@@ -408,8 +433,8 @@ KJUR.crypto.MessageDigest = function(params) {
      * @example
      * md.updateString('New York');
      */
-    this.updateString = function(str) {
-	throw "updateString(str) not supported for this alg/prov: " + this.algName + "/" + this.provName;
+    this.updateString = function() {
+        throw "updateString(str) not supported for this alg/prov: " + this.algName + "/" + this.provName;
     };
 
     /**
@@ -422,8 +447,8 @@ KJUR.crypto.MessageDigest = function(params) {
      * @example
      * md.updateHex('0afe36');
      */
-    this.updateHex = function(hex) {
-	throw "updateHex(hex) not supported for this alg/prov: " + this.algName + "/" + this.provName;
+    this.updateHex = function() {
+        throw "updateHex(hex) not supported for this alg/prov: " + this.algName + "/" + this.provName;
     };
 
     /**
@@ -436,7 +461,7 @@ KJUR.crypto.MessageDigest = function(params) {
      * md.digest()
      */
     this.digest = function() {
-	throw "digest() not supported for this alg/prov: " + this.algName + "/" + this.provName;
+        throw "digest() not supported for this alg/prov: " + this.algName + "/" + this.provName;
     };
 
     /**
@@ -449,8 +474,8 @@ KJUR.crypto.MessageDigest = function(params) {
      * @example
      * md.digestString('aaa')
      */
-    this.digestString = function(str) {
-	throw "digestString(str) not supported for this alg/prov: " + this.algName + "/" + this.provName;
+    this.digestString = function() {
+        throw "digestString(str) not supported for this alg/prov: " + this.algName + "/" + this.provName;
     };
 
     /**
@@ -463,22 +488,23 @@ KJUR.crypto.MessageDigest = function(params) {
      * @example
      * md.digestHex('0f2abd')
      */
-    this.digestHex = function(hex) {
-	throw "digestHex(hex) not supported for this alg/prov: " + this.algName + "/" + this.provName;
+    this.digestHex = function() {
+        throw "digestHex(hex) not supported for this alg/prov: " + this.algName + "/" + this.provName;
     };
 
     if (params !== undefined) {
-	if (params['alg'] !== undefined) {
-	    this.algName = params['alg'];
-	    if (params['prov'] === undefined)
-		this.provName = KJUR.crypto.Util.DEFAULTPROVIDER[this.algName];
-	    this.setAlgAndProvider(this.algName, this.provName);
-	}
+        if (params.alg !== undefined) {
+            this.algName = params.alg;
+            if (params.prov === undefined) {
+                this.provName = KJUR.crypto.Util.DEFAULTPROVIDER[this.algName];
+            }
+            this.setAlgAndProvider(this.algName, this.provName);
+        }
     }
 };
 
 /**
- * Mac(Message Authentication Code) class which is very similar to java.security.Mac class 
+ * Mac(Message Authentication Code) class which is very similar to java.security.Mac class
  * @name KJUR.crypto.Mac
  * @class Mac class which is very similar to java.security.Mac class
  * @param {Array} params parameters for constructor
@@ -502,54 +528,52 @@ KJUR.crypto.MessageDigest = function(params) {
  * var macHex = md.doFinal()
  */
 KJUR.crypto.Mac = function(params) {
-    var mac = null;
-    var pass = null;
-    var algName = null;
-    var provName = null;
-    var algProv = null;
-
     this.setAlgAndProvider = function(alg, prov) {
-	if (alg == null) alg = "hmacsha1";
+        if (alg === null) {
+            alg = "hmacsha1";
+        }
 
-	alg = alg.toLowerCase();
-        if (alg.substr(0, 4) != "hmac") {
-	    throw "setAlgAndProvider unsupported HMAC alg: " + alg;
-	}
+        alg = alg.toLowerCase();
+        if (alg.substr(0, 4) !== "hmac") {
+            throw "setAlgAndProvider unsupported HMAC alg: " + alg;
+        }
 
-	if (prov === undefined) prov = KJUR.crypto.Util.DEFAULTPROVIDER[alg];
-	this.algProv = alg + "/" + prov;
+        if (prov === undefined) {
+            prov = KJUR.crypto.Util.DEFAULTPROVIDER[alg];
+        }
+        this.algProv = alg + "/" + prov;
 
-	var hashAlg = alg.substr(4);
+        var hashAlg = alg.substr(4);
 
-	// for cryptojs
-	if (':md5:sha1:sha224:sha256:sha384:sha512:ripemd160:'.indexOf(hashAlg) != -1 &&
-	    prov == 'cryptojs') {
-	    try {
-		var mdObj = eval(KJUR.crypto.Util.CRYPTOJSMESSAGEDIGESTNAME[hashAlg]);
-		this.mac = CryptoJS.algo.HMAC.create(mdObj, this.pass);
-	    } catch (ex) {
-		throw "setAlgAndProvider hash alg set fail hashAlg=" + hashAlg + "/" + ex;
-	    }
-	    this.updateString = function(str) {
-		this.mac.update(str);
-	    };
-	    this.updateHex = function(hex) {
-		var wHex = CryptoJS.enc.Hex.parse(hex);
-		this.mac.update(wHex);
-	    };
-	    this.doFinal = function() {
-		var hash = this.mac.finalize();
-		return hash.toString(CryptoJS.enc.Hex);
-	    };
-	    this.doFinalString = function(str) {
-		this.updateString(str);
-		return this.doFinal();
-	    };
-	    this.doFinalHex = function(hex) {
-		this.updateHex(hex);
-		return this.doFinal();
-	    };
-	}
+        // for cryptojs
+        if (':md5:sha1:sha224:sha256:sha384:sha512:ripemd160:'.indexOf(hashAlg) !== -1 &&
+            prov === 'cryptojs') {
+            try {
+                var mdObj = KJUR.crypto.Util.CRYPTOJSMESSAGEDIGESTNAME[hashAlg];
+                this.mac = CryptoJS.algo.HMAC.create(mdObj, this.pass);
+            } catch (ex) {
+                throw "setAlgAndProvider hash alg set fail hashAlg=" + hashAlg + "/" + ex;
+            }
+            this.updateString = function(str) {
+                this.mac.update(str);
+            };
+            this.updateHex = function(hex) {
+                var wHex = CryptoJS.enc.Hex.parse(hex);
+                this.mac.update(wHex);
+            };
+            this.doFinal = function() {
+                var hash = this.mac.finalize();
+                return hash.toString(CryptoJS.enc.Hex);
+            };
+            this.doFinalString = function(str) {
+                this.updateString(str);
+                return this.doFinal();
+            };
+            this.doFinalHex = function(hex) {
+                this.updateHex(hex);
+                return this.doFinal();
+            };
+        }
     };
 
     /**
@@ -562,8 +586,8 @@ KJUR.crypto.Mac = function(params) {
      * @example
      * md.updateString('New York');
      */
-    this.updateString = function(str) {
-	throw "updateString(str) not supported for this alg/prov: " + this.algProv;
+    this.updateString = function() {
+        throw "updateString(str) not supported for this alg/prov: " + this.algProv;
     };
 
     /**
@@ -576,8 +600,8 @@ KJUR.crypto.Mac = function(params) {
      * @example
      * md.updateHex('0afe36');
      */
-    this.updateHex = function(hex) {
-	throw "updateHex(hex) not supported for this alg/prov: " + this.algProv;
+    this.updateHex = function() {
+        throw "updateHex(hex) not supported for this alg/prov: " + this.algProv;
     };
 
     /**
@@ -590,7 +614,7 @@ KJUR.crypto.Mac = function(params) {
      * md.digest()
      */
     this.doFinal = function() {
-	throw "digest() not supported for this alg/prov: " + this.algProv;
+        throw "digest() not supported for this alg/prov: " + this.algProv;
     };
 
     /**
@@ -603,12 +627,12 @@ KJUR.crypto.Mac = function(params) {
      * @example
      * md.digestString('aaa')
      */
-    this.doFinalString = function(str) {
-	throw "digestString(str) not supported for this alg/prov: " + this.algProv;
+    this.doFinalString = function() {
+        throw "digestString(str) not supported for this alg/prov: " + this.algProv;
     };
 
     /**
-     * performs final update on the digest using hexadecimal string, 
+     * performs final update on the digest using hexadecimal string,
      * then completes the digest computation
      * @name doFinalHex
      * @memberOf KJUR.crypto.Mac
@@ -618,20 +642,21 @@ KJUR.crypto.Mac = function(params) {
      * @example
      * md.digestHex('0f2abd')
      */
-    this.doFinalHex = function(hex) {
-	throw "digestHex(hex) not supported for this alg/prov: " + this.algProv;
+    this.doFinalHex = function() {
+        throw "digestHex(hex) not supported for this alg/prov: " + this.algProv;
     };
 
     if (params !== undefined) {
-	if (params['pass'] !== undefined) {
-	    this.pass = params['pass'];
-	}
-	if (params['alg'] !== undefined) {
-	    this.algName = params['alg'];
-	    if (params['prov'] === undefined)
-		this.provName = KJUR.crypto.Util.DEFAULTPROVIDER[this.algName];
-	    this.setAlgAndProvider(this.algName, this.provName);
-	}
+        if (params.pass !== undefined) {
+            this.pass = params.pass;
+        }
+        if (params.alg !== undefined) {
+            this.algName = params.alg;
+            if (params.prov === undefined) {
+                this.provName = KJUR.crypto.Util.DEFAULTPROVIDER[this.algName];
+            }
+            this.setAlgAndProvider(this.algName, this.provName);
+        }
     }
 };
 
@@ -696,7 +721,7 @@ KJUR.crypto.Mac = function(params) {
  * sig2.init(certPEM);
  * sig.updateString('aaa');
  * var isValid = sig2.verify(hSigVal);
- * 
+ *
  * // ECDSA signing
  * var sig = new KJUR.crypto.Signature({'alg':'SHA1withECDSA'});
  * sig.init(prvKeyPEM);
@@ -711,38 +736,21 @@ KJUR.crypto.Mac = function(params) {
  */
 KJUR.crypto.Signature = function(params) {
     var prvKey = null; // RSAKey/KJUR.crypto.{ECDSA,DSA} object for signing
-    var pubKey = null; // RSAKey/KJUR.crypto.{ECDSA,DSA} object for verifying
-
-    var md = null; // KJUR.crypto.MessageDigest object
-    var sig = null;
-    var algName = null;
-    var provName = null;
-    var algProvName = null;
-    var mdAlgName = null;
-    var pubkeyAlgName = null;	// rsa,ecdsa,rsaandmgf1(=rsapss)
-    var state = null;
-    var pssSaltLen = -1;
-    var initParams = null;
-
-    var sHashHex = null; // hex hash value for hex
-    var hDigestInfo = null;
-    var hPaddedDigestInfo = null;
-    var hSign = null;
 
     this._setAlgNames = function() {
-	if (this.algName.match(/^(.+)with(.+)$/)) {
-	    this.mdAlgName = RegExp.$1.toLowerCase();
-	    this.pubkeyAlgName = RegExp.$2.toLowerCase();
-	}
+        if (this.algName.match(/^(.+)with(.+)$/)) {
+            this.mdAlgName = RegExp.$1.toLowerCase();
+            this.pubkeyAlgName = RegExp.$2.toLowerCase();
+        }
     };
 
     this._zeroPaddingOfSignature = function(hex, bitLength) {
-	var s = "";
-	var nZero = bitLength / 4 - hex.length;
-	for (var i = 0; i < nZero; i++) {
-	    s = s + "0";
-	}
-	return s + hex;
+        var s = "";
+        var nZero = bitLength / 4 - hex.length;
+        for (var i = 0; i < nZero; i += 1) {
+            s = s + "0";
+        }
+        return s + hex;
     };
 
     /**
@@ -757,130 +765,137 @@ KJUR.crypto.Signature = function(params) {
      * md.setAlgAndProvider('SHA1withRSA', 'cryptojs/jsrsa');
      */
     this.setAlgAndProvider = function(alg, prov) {
-	this._setAlgNames();
-	if (prov != 'cryptojs/jsrsa')
-	    throw "provider not supported: " + prov;
+        this._setAlgNames();
+        if (prov !== 'cryptojs/jsrsa') {
+            throw "provider not supported: " + prov;
+        }
 
-	if (':md5:sha1:sha224:sha256:sha384:sha512:ripemd160:'.indexOf(this.mdAlgName) != -1) {
-	    try {
-		this.md = new KJUR.crypto.MessageDigest({'alg':this.mdAlgName});
-	    } catch (ex) {
-		throw "setAlgAndProvider hash alg set fail alg=" +
-                      this.mdAlgName + "/" + ex;
-	    }
+        if (':md5:sha1:sha224:sha256:sha384:sha512:ripemd160:'.indexOf(this.mdAlgName) !== -1) {
+            try {
+                this.md = new KJUR.crypto.MessageDigest({
+                    'alg': this.mdAlgName
+                });
+            } catch (ex) {
+                throw "setAlgAndProvider hash alg set fail alg=" +
+                this.mdAlgName + "/" + ex;
+            }
 
-	    this.init = function(keyparam, pass) {
-		var keyObj = null;
-		try {
-		    if (pass === undefined) {
-			keyObj = KEYUTIL.getKey(keyparam);
-		    } else {
-			keyObj = KEYUTIL.getKey(keyparam, pass);
-		    }
-		} catch (ex) {
-		    throw "init failed:" + ex;
-		}
+            this.init = function(keyparam, pass) {
+                var keyObj = null;
+                try {
+                    if (pass === undefined) {
+                        keyObj = KEYUTIL.getKey(keyparam);
+                    } else {
+                        keyObj = KEYUTIL.getKey(keyparam, pass);
+                    }
+                } catch (ex) {
+                    throw "init failed:" + ex;
+                }
 
-		if (keyObj.isPrivate === true) {
-		    this.prvKey = keyObj;
-		    this.state = "SIGN";
-		} else if (keyObj.isPublic === true) {
-		    this.pubKey = keyObj;
-		    this.state = "VERIFY";
-		} else {
-		    throw "init failed.:" + keyObj;
-		}
-	    };
+                if (keyObj.isPrivate === true) {
+                    this.prvKey = keyObj;
+                    this.state = "SIGN";
+                } else if (keyObj.isPublic === true) {
+                    this.pubKey = keyObj;
+                    this.state = "VERIFY";
+                } else {
+                    throw "init failed.:" + keyObj;
+                }
+            };
 
-	    this.initSign = function(params) {
-		if (typeof params['ecprvhex'] == 'string' &&
-                    typeof params['eccurvename'] == 'string') {
-		    this.ecprvhex = params['ecprvhex'];
-		    this.eccurvename = params['eccurvename'];
-		} else {
-		    this.prvKey = params;
-		}
-		this.state = "SIGN";
-	    };
+            this.initSign = function(params) {
+                if (typeof params.ecprvhex === 'string' &&
+                    typeof params.eccurvename === 'string') {
+                    this.ecprvhex = params.ecprvhex;
+                    this.eccurvename = params.eccurvename;
+                } else {
+                    this.prvKey = params;
+                }
+                this.state = "SIGN";
+            };
 
-	    this.initVerifyByPublicKey = function(params) {
-		if (typeof params['ecpubhex'] == 'string' &&
-		    typeof params['eccurvename'] == 'string') {
-		    this.ecpubhex = params['ecpubhex'];
-		    this.eccurvename = params['eccurvename'];
-		} else if (params instanceof KJUR.crypto.ECDSA) {
-		    this.pubKey = params;
-		} else if (params instanceof RSAKey) {
-		    this.pubKey = params;
-		}
-		this.state = "VERIFY";
-	    };
+            this.initVerifyByPublicKey = function(params) {
+                if (typeof params.ecpubhex === 'string' &&
+                    typeof params.eccurvename === 'string') {
+                    this.ecpubhex = params.ecpubhex;
+                    this.eccurvename = params.eccurvename;
+                } else if (params instanceof KJUR.crypto.ECDSA) {
+                    this.pubKey = params;
+                } else if (params instanceof RSAKey) {
+                    this.pubKey = params;
+                }
+                this.state = "VERIFY";
+            };
 
-	    this.initVerifyByCertificatePEM = function(certPEM) {
-		var x509 = new X509();
-		x509.readCertPEM(certPEM);
-		this.pubKey = x509.subjectPublicKeyRSA;
-		this.state = "VERIFY";
-	    };
+            this.initVerifyByCertificatePEM = function(certPEM) {
+                var x509 = new X509();
+                x509.readCertPEM(certPEM);
+                this.pubKey = x509.subjectPublicKeyRSA;
+                this.state = "VERIFY";
+            };
 
-	    this.updateString = function(str) {
-		this.md.updateString(str);
-	    };
-	    this.updateHex = function(hex) {
-		this.md.updateHex(hex);
-	    };
+            this.updateString = function(str) {
+                this.md.updateString(str);
+            };
+            this.updateHex = function(hex) {
+                this.md.updateHex(hex);
+            };
 
-	    this.sign = function() {
-		this.sHashHex = this.md.digest();
-		if (typeof this.ecprvhex != "undefined" &&
-		    typeof this.eccurvename != "undefined") {
-		    var ec = new KJUR.crypto.ECDSA({'curve': this.eccurvename});
-		    this.hSign = ec.signHex(this.sHashHex, this.ecprvhex);
-		} else if (this.pubkeyAlgName == "rsaandmgf1") {
-		    this.hSign = this.prvKey.signWithMessageHashPSS(this.sHashHex,
-								    this.mdAlgName,
-								    this.pssSaltLen);
-		} else if (this.pubkeyAlgName == "rsa") {
-		    this.hSign = this.prvKey.signWithMessageHash(this.sHashHex,
-								 this.mdAlgName);
-		} else if (this.prvKey instanceof KJUR.crypto.ECDSA) {
-		    this.hSign = this.prvKey.signWithMessageHash(this.sHashHex);
-		} else if (this.prvKey instanceof KJUR.crypto.DSA) {
-		    this.hSign = this.prvKey.signWithMessageHash(this.sHashHex);
-		} else {
-		    throw "Signature: unsupported public key alg: " + this.pubkeyAlgName;
-		}
-		return this.hSign;
-	    };
-	    this.signString = function(str) {
-		this.updateString(str);
-		return this.sign();
-	    };
-	    this.signHex = function(hex) {
-		this.updateHex(hex);
-		return this.sign();
-	    };
-	    this.verify = function(hSigVal) {
-	        this.sHashHex = this.md.digest();
-		if (typeof this.ecpubhex != "undefined" &&
-		    typeof this.eccurvename != "undefined") {
-		    var ec = new KJUR.crypto.ECDSA({curve: this.eccurvename});
-		    return ec.verifyHex(this.sHashHex, hSigVal, this.ecpubhex);
-		} else if (this.pubkeyAlgName == "rsaandmgf1") {
-		    return this.pubKey.verifyWithMessageHashPSS(this.sHashHex, hSigVal, 
-								this.mdAlgName,
-								this.pssSaltLen);
-		} else if (this.pubkeyAlgName == "rsa") {
-		    return this.pubKey.verifyWithMessageHash(this.sHashHex, hSigVal);
-		} else if (this.pubKey instanceof KJUR.crypto.ECDSA) {
-		    return this.pubKey.verifyWithMessageHash(this.sHashHex, hSigVal);
-		} else if (this.pubKey instanceof KJUR.crypto.DSA) {
-		    return this.pubKey.verifyWithMessageHash(this.sHashHex, hSigVal);
-		} else {
-		    throw "Signature: unsupported public key alg: " + this.pubkeyAlgName;
-		}
-	    };
-	}
+            this.sign = function() {
+                this.sHashHex = this.md.digest();
+                if (typeof this.ecprvhex !== "undefined" &&
+                    typeof this.eccurvename !== "undefined") {
+                    var ec = new KJUR.crypto.ECDSA({
+                        'curve': this.eccurvename
+                    });
+                    this.hSign = ec.signHex(this.sHashHex, this.ecprvhex);
+                } else if (this.pubkeyAlgName === "rsaandmgf1") {
+                    this.hSign = this.prvKey.signWithMessageHashPSS(this.sHashHex,
+                        this.mdAlgName,
+                        this.pssSaltLen);
+                } else if (this.pubkeyAlgName === "rsa") {
+                    this.hSign = this.prvKey.signWithMessageHash(this.sHashHex,
+                        this.mdAlgName);
+                } else if (this.prvKey instanceof KJUR.crypto.ECDSA) {
+                    this.hSign = this.prvKey.signWithMessageHash(this.sHashHex);
+                } else if (this.prvKey instanceof KJUR.crypto.DSA) {
+                    this.hSign = this.prvKey.signWithMessageHash(this.sHashHex);
+                } else {
+                    throw "Signature: unsupported public key alg: " + this.pubkeyAlgName;
+                }
+                return this.hSign;
+            };
+            this.signString = function(str) {
+                this.updateString(str);
+                return this.sign();
+            };
+            this.signHex = function(hex) {
+                this.updateHex(hex);
+                return this.sign();
+            };
+            this.verify = function(hSigVal) {
+                this.sHashHex = this.md.digest();
+                if (typeof this.ecpubhex !== "undefined" &&
+                    typeof this.eccurvename !== "undefined") {
+                    var ec = new KJUR.crypto.ECDSA({
+                        curve: this.eccurvename
+                    });
+                    return ec.verifyHex(this.sHashHex, hSigVal, this.ecpubhex);
+                } else if (this.pubkeyAlgName === "rsaandmgf1") {
+                    return this.pubKey.verifyWithMessageHashPSS(this.sHashHex, hSigVal,
+                        this.mdAlgName,
+                        this.pssSaltLen);
+                } else if (this.pubkeyAlgName === "rsa") {
+                    return this.pubKey.verifyWithMessageHash(this.sHashHex, hSigVal);
+                } else if (this.pubKey instanceof KJUR.crypto.ECDSA) {
+                    return this.pubKey.verifyWithMessageHash(this.sHashHex, hSigVal);
+                } else if (this.pubKey instanceof KJUR.crypto.DSA) {
+                    return this.pubKey.verifyWithMessageHash(this.sHashHex, hSigVal);
+                } else {
+                    throw "Signature: unsupported public key alg: " + this.pubkeyAlgName;
+                }
+            };
+        }
     };
 
     /**
@@ -918,9 +933,9 @@ KJUR.crypto.Signature = function(params) {
      * @example
      * sig.init(sCertPEM)
      */
-    this.init = function(key, pass) {
-	throw "init(key, pass) not supported for this alg:prov=" +
-	      this.algProvName;
+    this.init = function() {
+        throw "init(key, pass) not supported for this alg:prov=" +
+        this.algProvName;
     };
 
     /**
@@ -943,9 +958,9 @@ KJUR.crypto.Signature = function(params) {
      * @example
      * sig.initVerifyByPublicKey(rsaPrvKey)
      */
-    this.initVerifyByPublicKey = function(rsaPubKey) {
-	throw "initVerifyByPublicKey(rsaPubKeyy) not supported for this alg:prov=" +
-	      this.algProvName;
+    this.initVerifyByPublicKey = function() {
+        throw "initVerifyByPublicKey(rsaPubKeyy) not supported for this alg:prov=" +
+        this.algProvName;
     };
 
     /**
@@ -960,9 +975,9 @@ KJUR.crypto.Signature = function(params) {
      * @example
      * sig.initVerifyByCertificatePEM(certPEM)
      */
-    this.initVerifyByCertificatePEM = function(certPEM) {
-	throw "initVerifyByCertificatePEM(certPEM) not supported for this alg:prov=" +
-	    this.algProvName;
+    this.initVerifyByCertificatePEM = function() {
+        throw "initVerifyByCertificatePEM(certPEM) not supported for this alg:prov=" +
+        this.algProvName;
     };
 
     /**
@@ -983,8 +998,8 @@ KJUR.crypto.Signature = function(params) {
      * @example
      * sig.initSign(prvKey)
      */
-    this.initSign = function(prvKey) {
-	throw "initSign(prvKey) not supported for this alg:prov=" + this.algProvName;
+    this.initSign = function() {
+        throw "initSign(prvKey) not supported for this alg:prov=" + this.algProvName;
     };
 
     /**
@@ -997,8 +1012,8 @@ KJUR.crypto.Signature = function(params) {
      * @example
      * sig.updateString('aaa')
      */
-    this.updateString = function(str) {
-	throw "updateString(str) not supported for this alg:prov=" + this.algProvName;
+    this.updateString = function() {
+        throw "updateString(str) not supported for this alg:prov=" + this.algProvName;
     };
 
     /**
@@ -1011,8 +1026,8 @@ KJUR.crypto.Signature = function(params) {
      * @example
      * sig.updateHex('1f2f3f')
      */
-    this.updateHex = function(hex) {
-	throw "updateHex(hex) not supported for this alg:prov=" + this.algProvName;
+    this.updateHex = function() {
+        throw "updateHex(hex) not supported for this alg:prov=" + this.algProvName;
     };
 
     /**
@@ -1026,7 +1041,7 @@ KJUR.crypto.Signature = function(params) {
      * var hSigValue = sig.sign()
      */
     this.sign = function() {
-	throw "sign() not supported for this alg:prov=" + this.algProvName;
+        throw "sign() not supported for this alg:prov=" + this.algProvName;
     };
 
     /**
@@ -1040,8 +1055,8 @@ KJUR.crypto.Signature = function(params) {
      * @example
      * var hSigValue = sig.signString('aaa')
      */
-    this.signString = function(str) {
-	throw "digestString(str) not supported for this alg:prov=" + this.algProvName;
+    this.signString = function() {
+        throw "digestString(str) not supported for this alg:prov=" + this.algProvName;
     };
 
     /**
@@ -1055,8 +1070,8 @@ KJUR.crypto.Signature = function(params) {
      * @example
      * var hSigValue = sig.signHex('1fdc33')
      */
-    this.signHex = function(hex) {
-	throw "digestHex(hex) not supported for this alg:prov=" + this.algProvName;
+    this.signHex = function() {
+        throw "digestHex(hex) not supported for this alg:prov=" + this.algProvName;
     };
 
     /**
@@ -1070,40 +1085,42 @@ KJUR.crypto.Signature = function(params) {
      * @example
      * var isValid = sig.verify('1fbcefdca4823a7(snip)')
      */
-    this.verify = function(hSigVal) {
-	throw "verify(hSigVal) not supported for this alg:prov=" + this.algProvName;
+    this.verify = function() {
+        throw "verify(hSigVal) not supported for this alg:prov=" + this.algProvName;
     };
 
     this.initParams = params;
 
     if (params !== undefined) {
-	if (params['alg'] !== undefined) {
-	    this.algName = params['alg'];
-	    if (params['prov'] === undefined) {
-		this.provName = KJUR.crypto.Util.DEFAULTPROVIDER[this.algName];
-	    } else {
-		this.provName = params['prov'];
-	    }
-	    this.algProvName = this.algName + ":" + this.provName;
-	    this.setAlgAndProvider(this.algName, this.provName);
-	    this._setAlgNames();
-	}
+        if (params.alg !== undefined) {
+            this.algName = params.alg;
+            if (params.prov === undefined) {
+                this.provName = KJUR.crypto.Util.DEFAULTPROVIDER[this.algName];
+            } else {
+                this.provName = params.prov;
+            }
+            this.algProvName = this.algName + ":" + this.provName;
+            this.setAlgAndProvider(this.algName, this.provName);
+            this._setAlgNames();
+        }
 
-	if (params['psssaltlen'] !== undefined) this.pssSaltLen = params['psssaltlen'];
+        if (params.psssaltlen !== undefined) {
+            this.pssSaltLen = params.psssaltlen;
+        }
 
-	if (params['prvkeypem'] !== undefined) {
-	    if (params['prvkeypas'] !== undefined) {
-		throw "both prvkeypem and prvkeypas parameters not supported";
-	    } else {
-		try {
-		    var prvKey = new RSAKey();
-		    prvKey.readPrivateKeyFromPEMString(params['prvkeypem']);
-		    this.initSign(prvKey);
-		} catch (ex) {
-		    throw "fatal error to load pem private key: " + ex;
-		}
-	    }
-	}
+        if (params.prvkeypem !== undefined) {
+            if (params.prvkeypas !== undefined) {
+                throw "both prvkeypem and prvkeypas parameters not supported";
+            } else {
+                try {
+                    prvKey = new RSAKey();
+                    prvKey.readPrivateKeyFromPEMString(params.prvkeypem);
+                    this.initSign(prvKey);
+                } catch (ex) {
+                    throw "fatal error to load pem private key: " + ex;
+                }
+            }
+        }
     }
 };
 
@@ -1118,19 +1135,19 @@ KJUR.crypto.Signature = function(params) {
  */
 
 
-KJUR.crypto.OID = new function() {
-    this.oidhex2name = {
-	'2a864886f70d010101': 'rsaEncryption',
-	'2a8648ce3d0201': 'ecPublicKey',
-	'2a8648ce380401': 'dsa',
-	'2a8648ce3d030107': 'secp256r1',
-	'2b8104001f': 'secp192k1',
-	'2b81040021': 'secp224r1',
-	'2b8104000a': 'secp256k1',
-	'2b81040023': 'secp521r1',
-	'2b81040022': 'secp384r1',
-	'2a8648ce380403': 'SHA1withDSA', // 1.2.840.10040.4.3
-	'608648016503040301': 'SHA224withDSA', // 2.16.840.1.101.3.4.3.1
-	'608648016503040302': 'SHA256withDSA', // 2.16.840.1.101.3.4.3.2
-    };
+KJUR.crypto.OID = {
+    oidhex2name: {
+        '2a864886f70d010101': 'rsaEncryption',
+        '2a8648ce3d0201': 'ecPublicKey',
+        '2a8648ce380401': 'dsa',
+        '2a8648ce3d030107': 'secp256r1',
+        '2b8104001f': 'secp192k1',
+        '2b81040021': 'secp224r1',
+        '2b8104000a': 'secp256k1',
+        '2b81040023': 'secp521r1',
+        '2b81040022': 'secp384r1',
+        '2a8648ce380403': 'SHA1withDSA', // 1.2.840.10040.4.3
+        '608648016503040301': 'SHA224withDSA', // 2.16.840.1.101.3.4.3.1
+        '608648016503040302': 'SHA256withDSA', // 2.16.840.1.101.3.4.3.2
+    }
 };

--- a/crypto-1.1.js
+++ b/crypto-1.1.js
@@ -1,1153 +1,1156 @@
-"use strict";
+(function() {
+    "use strict";
 
-/*! crypto-1.1.5.js (c) 2013 Kenji Urushima | kjur.github.com/jsrsasign/license
- */
-/*
- * crypto.js - Cryptographic Algorithm Provider class
- *
- * Copyright (c) 2013 Kenji Urushima (kenji.urushima@gmail.com)
- *
- * This software is licensed under the terms of the MIT License.
- * http://kjur.github.com/jsrsasign/license
- *
- * The above copyright and license notice shall be
- * included in all copies or substantial portions of the Software.
- */
-
-/**
- * @fileOverview
- * @name crypto-1.1.js
- * @author Kenji Urushima kenji.urushima@gmail.com
- * @version 1.1.5 (2013-Oct-06)
- * @since jsrsasign 2.2
- * @license <a href="http://kjur.github.io/jsrsasign/license/">MIT License</a>
- */
-
-/**
- * kjur's class library name space
- * @name KJUR
- * @namespace kjur's class library name space
- */
-if (typeof KJUR === "undefined" || !KJUR) {
-    var KJUR = {};
-}
-/**
- * kjur's cryptographic algorithm provider library name space
- * <p>
- * This namespace privides following crytpgrahic classes.
- * <ul>
- * <li>{@link KJUR.crypto.MessageDigest} - Java JCE(cryptograhic extension) style MessageDigest class</li>
- * <li>{@link KJUR.crypto.Signature} - Java JCE(cryptograhic extension) style Signature class</li>
- * <li>{@link KJUR.crypto.Util} - cryptographic utility functions and properties</li>
- * </ul>
- * NOTE: Please ignore method summary and document of this namespace. This caused by a bug of jsdoc2.
- * </p>
- * @name KJUR.crypto
- * @namespace
- */
-if (typeof KJUR.crypto === "undefined" || !KJUR.crypto) {
-    KJUR.crypto = {};
-}
-
-/**
- * static object for cryptographic function utilities
- * @name KJUR.crypto.Util
- * @class static object for cryptographic function utilities
- * @property {Array} DIGESTINFOHEAD PKCS#1 DigestInfo heading hexadecimal bytes for each hash algorithms
- * @property {Array} DEFAULTPROVIDER associative array of default provider name for each hash and signature algorithms
- * @description
- */
-KJUR.crypto.Util = {
-    DIGESTINFOHEAD: {
-        'sha1': "3021300906052b0e03021a05000414",
-        'sha224': "302d300d06096086480165030402040500041c",
-        'sha256': "3031300d060960864801650304020105000420",
-        'sha384': "3041300d060960864801650304020205000430",
-        'sha512': "3051300d060960864801650304020305000440",
-        'md2': "3020300c06082a864886f70d020205000410",
-        'md5': "3020300c06082a864886f70d020505000410",
-        'ripemd160': "3021300906052b2403020105000414",
-    },
-
+    /*! crypto-1.1.5.js (c) 2013 Kenji Urushima | kjur.github.com/jsrsasign/license
+     */
     /*
-     * @since crypto 1.1.1
+     * crypto.js - Cryptographic Algorithm Provider class
+     *
+     * Copyright (c) 2013 Kenji Urushima (kenji.urushima@gmail.com)
+     *
+     * This software is licensed under the terms of the MIT License.
+     * http://kjur.github.com/jsrsasign/license
+     *
+     * The above copyright and license notice shall be
+     * included in all copies or substantial portions of the Software.
      */
-    DEFAULTPROVIDER: {
-        'md5': 'cryptojs',
-        'sha1': 'cryptojs',
-        'sha224': 'cryptojs',
-        'sha256': 'cryptojs',
-        'sha384': 'cryptojs',
-        'sha512': 'cryptojs',
-        'ripemd160': 'cryptojs',
-        'hmacmd5': 'cryptojs',
-        'hmacsha1': 'cryptojs',
-        'hmacsha224': 'cryptojs',
-        'hmacsha256': 'cryptojs',
-        'hmacsha384': 'cryptojs',
-        'hmacsha512': 'cryptojs',
-        'hmacripemd160': 'cryptojs',
-
-        'MD5withRSA': 'cryptojs/jsrsa',
-        'SHA1withRSA': 'cryptojs/jsrsa',
-        'SHA224withRSA': 'cryptojs/jsrsa',
-        'SHA256withRSA': 'cryptojs/jsrsa',
-        'SHA384withRSA': 'cryptojs/jsrsa',
-        'SHA512withRSA': 'cryptojs/jsrsa',
-        'RIPEMD160withRSA': 'cryptojs/jsrsa',
-
-        'MD5withECDSA': 'cryptojs/jsrsa',
-        'SHA1withECDSA': 'cryptojs/jsrsa',
-        'SHA224withECDSA': 'cryptojs/jsrsa',
-        'SHA256withECDSA': 'cryptojs/jsrsa',
-        'SHA384withECDSA': 'cryptojs/jsrsa',
-        'SHA512withECDSA': 'cryptojs/jsrsa',
-        'RIPEMD160withECDSA': 'cryptojs/jsrsa',
-
-        'SHA1withDSA': 'cryptojs/jsrsa',
-        'SHA224withDSA': 'cryptojs/jsrsa',
-        'SHA256withDSA': 'cryptojs/jsrsa',
-
-        'MD5withRSAandMGF1': 'cryptojs/jsrsa',
-        'SHA1withRSAandMGF1': 'cryptojs/jsrsa',
-        'SHA224withRSAandMGF1': 'cryptojs/jsrsa',
-        'SHA256withRSAandMGF1': 'cryptojs/jsrsa',
-        'SHA384withRSAandMGF1': 'cryptojs/jsrsa',
-        'SHA512withRSAandMGF1': 'cryptojs/jsrsa',
-        'RIPEMD160withRSAandMGF1': 'cryptojs/jsrsa',
-    },
-
-    /*
-     * @since crypto 1.1.2
-     */
-    CRYPTOJSMESSAGEDIGESTNAME: {
-        'md5': CryptoJS.algo.MD5,
-        'sha1': CryptoJS.algo.SHA1,
-        'sha224': CryptoJS.algo.SHA224,
-        'sha256': CryptoJS.algo.SHA256,
-        'sha384': CryptoJS.algo.SHA384,
-        'sha512': CryptoJS.algo.SHA512,
-        'ripemd160': CryptoJS.algo.RIPEMD160
-    },
 
     /**
-     * get hexadecimal DigestInfo
-     * @name getDigestInfoHex
-     * @memberOf KJUR.crypto.Util
-     * @function
-     * @param {String} hHash hexadecimal hash value
-     * @param {String} alg hash algorithm name (ex. 'sha1')
-     * @return {String} hexadecimal string DigestInfo ASN.1 structure
+     * @fileOverview
+     * @name crypto-1.1.js
+     * @author Kenji Urushima kenji.urushima@gmail.com
+     * @version 1.1.5 (2013-Oct-06)
+     * @since jsrsasign 2.2
+     * @license <a href="http://kjur.github.io/jsrsasign/license/">MIT License</a>
      */
-    getDigestInfoHex: function(hHash, alg) {
-        if (typeof this.DIGESTINFOHEAD[alg] === "undefined") {
-            throw "alg not supported in Util.DIGESTINFOHEAD: " + alg;
-        }
-        return this.DIGESTINFOHEAD[alg] + hHash;
-    },
 
     /**
-     * get PKCS#1 padded hexadecimal DigestInfo
-     * @name getPaddedDigestInfoHex
-     * @memberOf KJUR.crypto.Util
-     * @function
-     * @param {String} hHash hexadecimal hash value of message to be signed
-     * @param {String} alg hash algorithm name (ex. 'sha1')
-     * @param {Integer} keySize key bit length (ex. 1024)
-     * @return {String} hexadecimal string of PKCS#1 padded DigestInfo
+     * kjur's class library name space
+     * @name KJUR
+     * @namespace kjur's class library name space
      */
-    getPaddedDigestInfoHex: function(hHash, alg, keySize) {
-        var hDigestInfo = this.getDigestInfoHex(hHash, alg);
-        var pmStrLen = keySize / 4; // minimum PM length
 
-        if ( // len(0001+ff(*8)+00+hDigestInfo)=22
-            hDigestInfo.length + 22 > pmStrLen) {
-            throw "key is too short for SigAlg: keylen=" + keySize + "," + alg;
-        }
-
-        var hHead = "0001";
-        var hTail = "00" + hDigestInfo;
-        var hMid = "";
-        var fLen = pmStrLen - hHead.length - hTail.length;
-        for (var i = 0; i < fLen; i += 2) {
-            hMid += "ff";
-        }
-        var hPaddedMessage = hHead + hMid + hTail;
-        return hPaddedMessage;
-    },
-
-    /**
-     * get hexadecimal hash of string with specified algorithm
-     * @name hashString
-     * @memberOf KJUR.crypto.Util
-     * @function
-     * @param {String} s input string to be hashed
-     * @param {String} alg hash algorithm name
-     * @return {String} hexadecimal string of hash value
-     * @since 1.1.1
-     */
-    hashString: function(s, alg) {
-        var md = new KJUR.crypto.MessageDigest({
-            'alg': alg
-        });
-        return md.digestString(s);
-    },
-
-    /**
-     * get hexadecimal hash of hexadecimal string with specified algorithm
-     * @name hashHex
-     * @memberOf KJUR.crypto.Util
-     * @function
-     * @param {String} sHex input hexadecimal string to be hashed
-     * @param {String} alg hash algorithm name
-     * @return {String} hexadecimal string of hash value
-     * @since 1.1.1
-     */
-    hashHex: function(sHex, alg) {
-        var md = new KJUR.crypto.MessageDigest({
-            'alg': alg
-        });
-        return md.digestHex(sHex);
-    },
-
-    /**
-     * get hexadecimal SHA1 hash of string
-     * @name sha1
-     * @memberOf KJUR.crypto.Util
-     * @function
-     * @param {String} s input string to be hashed
-     * @return {String} hexadecimal string of hash value
-     * @since 1.0.3
-     */
-    sha1: function(s) {
-        var md = new KJUR.crypto.MessageDigest({
-            'alg': 'sha1',
-            'prov': 'cryptojs'
-        });
-        return md.digestString(s);
-    },
-
-    /**
-     * get hexadecimal SHA256 hash of string
-     * @name sha256
-     * @memberOf KJUR.crypto.Util
-     * @function
-     * @param {String} s input string to be hashed
-     * @return {String} hexadecimal string of hash value
-     * @since 1.0.3
-     */
-    sha256: function(s) {
-        var md = new KJUR.crypto.MessageDigest({
-            'alg': 'sha256',
-            'prov': 'cryptojs'
-        });
-        return md.digestString(s);
-    },
-
-    sha256Hex: function(s) {
-        var md = new KJUR.crypto.MessageDigest({
-            'alg': 'sha256',
-            'prov': 'cryptojs'
-        });
-        return md.digestHex(s);
-    },
-
-    /**
-     * get hexadecimal SHA512 hash of string
-     * @name sha512
-     * @memberOf KJUR.crypto.Util
-     * @function
-     * @param {String} s input string to be hashed
-     * @return {String} hexadecimal string of hash value
-     * @since 1.0.3
-     */
-    sha512: function(s) {
-        var md = new KJUR.crypto.MessageDigest({
-            'alg': 'sha512',
-            'prov': 'cryptojs'
-        });
-        return md.digestString(s);
-    },
-
-    sha512Hex: function(s) {
-        var md = new KJUR.crypto.MessageDigest({
-            'alg': 'sha512',
-            'prov': 'cryptojs'
-        });
-        return md.digestHex(s);
-    },
-
-    /**
-     * get hexadecimal MD5 hash of string
-     * @name md5
-     * @memberOf KJUR.crypto.Util
-     * @function
-     * @param {String} s input string to be hashed
-     * @return {String} hexadecimal string of hash value
-     * @since 1.0.3
-     */
-    md5: function(s) {
-        var md = new KJUR.crypto.MessageDigest({
-            'alg': 'md5',
-            'prov': 'cryptojs'
-        });
-        return md.digestString(s);
-    },
-
-    /**
-     * get hexadecimal RIPEMD160 hash of string
-     * @name ripemd160
-     * @memberOf KJUR.crypto.Util
-     * @function
-     * @param {String} s input string to be hashed
-     * @return {String} hexadecimal string of hash value
-     * @since 1.0.3
-     */
-    ripemd160: function(s) {
-        var md = new KJUR.crypto.MessageDigest({
-            'alg': 'ripemd160',
-            'prov': 'cryptojs'
-        });
-        return md.digestString(s);
+    if (typeof KJUR === "undefined" || !KJUR) {
+        this.KJUR = {};
     }
-};
-
-/**
- * MessageDigest class which is very similar to java.security.MessageDigest class
- * @name KJUR.crypto.MessageDigest
- * @class MessageDigest class which is very similar to java.security.MessageDigest class
- * @param {Array} params parameters for constructor
- * @description
- * <br/>
- * Currently this supports following algorithm and providers combination:
- * <ul>
- * <li>md5 - cryptojs</li>
- * <li>sha1 - cryptojs</li>
- * <li>sha224 - cryptojs</li>
- * <li>sha256 - cryptojs</li>
- * <li>sha384 - cryptojs</li>
- * <li>sha512 - cryptojs</li>
- * <li>ripemd160 - cryptojs</li>
- * <li>sha256 - sjcl (NEW from crypto.js 1.0.4)</li>
- * </ul>
- * @example
- * // CryptoJS provider sample
- * &lt;script src="http://crypto-js.googlecode.com/svn/tags/3.1.2/build/components/core.js"&gt;&lt;/script&gt;
- * &lt;script src="http://crypto-js.googlecode.com/svn/tags/3.1.2/build/components/sha1.js"&gt;&lt;/script&gt;
- * &lt;script src="crypto-1.0.js"&gt;&lt;/script&gt;
- * var md = new KJUR.crypto.MessageDigest({alg: "sha1", prov: "cryptojs"});
- * md.updateString('aaa')
- * var mdHex = md.digest()
- *
- * // SJCL(Stanford JavaScript Crypto Library) provider sample
- * &lt;script src="http://bitwiseshiftleft.github.io/sjcl/sjcl.js"&gt;&lt;/script&gt;
- * &lt;script src="crypto-1.0.js"&gt;&lt;/script&gt;
- * var md = new KJUR.crypto.MessageDigest({alg: "sha256", prov: "sjcl"}); // sjcl supports sha256 only
- * md.updateString('aaa')
- * var mdHex = md.digest()
- */
-KJUR.crypto.MessageDigest = function(params) {
     /**
-     * set hash algorithm and provider
-     * @name setAlgAndProvider
-     * @memberOf KJUR.crypto.MessageDigest
-     * @function
-     * @param {String} alg hash algorithm name
-     * @param {String} prov provider name
-     * @description
-     * @example
-     * // for SHA1
-     * md.setAlgAndProvider('sha1', 'cryptojs');
-     * // for RIPEMD160
-     * md.setAlgAndProvider('ripemd160', 'cryptojs');
+     * kjur's cryptographic algorithm provider library name space
+     * <p>
+     * This namespace privides following crytpgrahic classes.
+     * <ul>
+     * <li>{@link KJUR.crypto.MessageDigest} - Java JCE(cryptograhic extension) style MessageDigest class</li>
+     * <li>{@link KJUR.crypto.Signature} - Java JCE(cryptograhic extension) style Signature class</li>
+     * <li>{@link KJUR.crypto.Util} - cryptographic utility functions and properties</li>
+     * </ul>
+     * NOTE: Please ignore method summary and document of this namespace. This caused by a bug of jsdoc2.
+     * </p>
+     * @name KJUR.crypto
+     * @namespace
      */
-    this.setAlgAndProvider = function(alg, prov) {
-        if (alg !== null && prov === undefined) {
-            prov = KJUR.crypto.Util.DEFAULTPROVIDER[alg];
-        }
-
-        // for cryptojs
-        if (':md5:sha1:sha224:sha256:sha384:sha512:ripemd160:'.indexOf(alg) !== -1 &&
-            prov === 'cryptojs') {
-            try {
-                this.md = KJUR.crypto.Util.CRYPTOJSMESSAGEDIGESTNAME[alg].create();
-            } catch (ex) {
-                throw "setAlgAndProvider hash alg set fail alg=" + alg + "/" + ex;
-            }
-            this.updateString = function(str) {
-                this.md.update(str);
-            };
-            this.updateHex = function(hex) {
-                var wHex = CryptoJS.enc.Hex.parse(hex);
-                this.md.update(wHex);
-            };
-            this.digest = function() {
-                var hash = this.md.finalize();
-                return hash.toString(CryptoJS.enc.Hex);
-            };
-            this.digestString = function(str) {
-                this.updateString(str);
-                return this.digest();
-            };
-            this.digestHex = function(hex) {
-                this.updateHex(hex);
-                return this.digest();
-            };
-        }
-        if (':sha256:'.indexOf(alg) !== -1 &&
-            prov === 'sjcl') {
-            try {
-                this.md = new sjcl.hash.sha256();
-            } catch (ex) {
-                throw "setAlgAndProvider hash alg set fail alg=" + alg + "/" + ex;
-            }
-            this.updateString = function(str) {
-                this.md.update(str);
-            };
-            this.updateHex = function(hex) {
-                var baHex = sjcl.codec.hex.toBits(hex);
-                this.md.update(baHex);
-            };
-            this.digest = function() {
-                var hash = this.md.finalize();
-                return sjcl.codec.hex.fromBits(hash);
-            };
-            this.digestString = function(str) {
-                this.updateString(str);
-                return this.digest();
-            };
-            this.digestHex = function(hex) {
-                this.updateHex(hex);
-                return this.digest();
-            };
-        }
-    };
-
-    /**
-     * update digest by specified string
-     * @name updateString
-     * @memberOf KJUR.crypto.MessageDigest
-     * @function
-     * @param {String} str string to update
-     * @description
-     * @example
-     * md.updateString('New York');
-     */
-    this.updateString = function() {
-        throw "updateString(str) not supported for this alg/prov: " + this.algName + "/" + this.provName;
-    };
-
-    /**
-     * update digest by specified hexadecimal string
-     * @name updateHex
-     * @memberOf KJUR.crypto.MessageDigest
-     * @function
-     * @param {String} hex hexadecimal string to update
-     * @description
-     * @example
-     * md.updateHex('0afe36');
-     */
-    this.updateHex = function() {
-        throw "updateHex(hex) not supported for this alg/prov: " + this.algName + "/" + this.provName;
-    };
-
-    /**
-     * completes hash calculation and returns hash result
-     * @name digest
-     * @memberOf KJUR.crypto.MessageDigest
-     * @function
-     * @description
-     * @example
-     * md.digest()
-     */
-    this.digest = function() {
-        throw "digest() not supported for this alg/prov: " + this.algName + "/" + this.provName;
-    };
-
-    /**
-     * performs final update on the digest using string, then completes the digest computation
-     * @name digestString
-     * @memberOf KJUR.crypto.MessageDigest
-     * @function
-     * @param {String} str string to final update
-     * @description
-     * @example
-     * md.digestString('aaa')
-     */
-    this.digestString = function() {
-        throw "digestString(str) not supported for this alg/prov: " + this.algName + "/" + this.provName;
-    };
-
-    /**
-     * performs final update on the digest using hexadecimal string, then completes the digest computation
-     * @name digestHex
-     * @memberOf KJUR.crypto.MessageDigest
-     * @function
-     * @param {String} hex hexadecimal string to final update
-     * @description
-     * @example
-     * md.digestHex('0f2abd')
-     */
-    this.digestHex = function() {
-        throw "digestHex(hex) not supported for this alg/prov: " + this.algName + "/" + this.provName;
-    };
-
-    if (params !== undefined) {
-        if (params.alg !== undefined) {
-            this.algName = params.alg;
-            if (params.prov === undefined) {
-                this.provName = KJUR.crypto.Util.DEFAULTPROVIDER[this.algName];
-            }
-            this.setAlgAndProvider(this.algName, this.provName);
-        }
+    if (typeof KJUR.crypto === "undefined" || !KJUR.crypto) {
+        KJUR.crypto = {};
     }
-};
 
-/**
- * Mac(Message Authentication Code) class which is very similar to java.security.Mac class
- * @name KJUR.crypto.Mac
- * @class Mac class which is very similar to java.security.Mac class
- * @param {Array} params parameters for constructor
- * @description
- * <br/>
- * Currently this supports following algorithm and providers combination:
- * <ul>
- * <li>hmacmd5 - cryptojs</li>
- * <li>hmacsha1 - cryptojs</li>
- * <li>hmacsha224 - cryptojs</li>
- * <li>hmacsha256 - cryptojs</li>
- * <li>hmacsha384 - cryptojs</li>
- * <li>hmacsha512 - cryptojs</li>
- * </ul>
- * NOTE: HmacSHA224 and HmacSHA384 issue was fixed since jsrsasign 4.1.4.
- * Please use 'ext/cryptojs-312-core-fix*.js' instead of 'core.js' of original CryptoJS
- * to avoid those issue.
- * @example
- * var mac = new KJUR.crypto.Mac({alg: "HmacSHA1", prov: "cryptojs", "pass": "pass"});
- * mac.updateString('aaa')
- * var macHex = md.doFinal()
- */
-KJUR.crypto.Mac = function(params) {
-    this.setAlgAndProvider = function(alg, prov) {
-        if (alg === null) {
-            alg = "hmacsha1";
-        }
+    /**
+     * static object for cryptographic function utilities
+     * @name KJUR.crypto.Util
+     * @class static object for cryptographic function utilities
+     * @property {Array} DIGESTINFOHEAD PKCS#1 DigestInfo heading hexadecimal bytes for each hash algorithms
+     * @property {Array} DEFAULTPROVIDER associative array of default provider name for each hash and signature algorithms
+     * @description
+     */
+    KJUR.crypto.Util = {
+        DIGESTINFOHEAD: {
+            'sha1': "3021300906052b0e03021a05000414",
+            'sha224': "302d300d06096086480165030402040500041c",
+            'sha256': "3031300d060960864801650304020105000420",
+            'sha384': "3041300d060960864801650304020205000430",
+            'sha512': "3051300d060960864801650304020305000440",
+            'md2': "3020300c06082a864886f70d020205000410",
+            'md5': "3020300c06082a864886f70d020505000410",
+            'ripemd160': "3021300906052b2403020105000414",
+        },
 
-        alg = alg.toLowerCase();
-        if (alg.substr(0, 4) !== "hmac") {
-            throw "setAlgAndProvider unsupported HMAC alg: " + alg;
-        }
+        /*
+         * @since crypto 1.1.1
+         */
+        DEFAULTPROVIDER: {
+            'md5': 'cryptojs',
+            'sha1': 'cryptojs',
+            'sha224': 'cryptojs',
+            'sha256': 'cryptojs',
+            'sha384': 'cryptojs',
+            'sha512': 'cryptojs',
+            'ripemd160': 'cryptojs',
+            'hmacmd5': 'cryptojs',
+            'hmacsha1': 'cryptojs',
+            'hmacsha224': 'cryptojs',
+            'hmacsha256': 'cryptojs',
+            'hmacsha384': 'cryptojs',
+            'hmacsha512': 'cryptojs',
+            'hmacripemd160': 'cryptojs',
 
-        if (prov === undefined) {
-            prov = KJUR.crypto.Util.DEFAULTPROVIDER[alg];
-        }
-        this.algProv = alg + "/" + prov;
+            'MD5withRSA': 'cryptojs/jsrsa',
+            'SHA1withRSA': 'cryptojs/jsrsa',
+            'SHA224withRSA': 'cryptojs/jsrsa',
+            'SHA256withRSA': 'cryptojs/jsrsa',
+            'SHA384withRSA': 'cryptojs/jsrsa',
+            'SHA512withRSA': 'cryptojs/jsrsa',
+            'RIPEMD160withRSA': 'cryptojs/jsrsa',
 
-        var hashAlg = alg.substr(4);
+            'MD5withECDSA': 'cryptojs/jsrsa',
+            'SHA1withECDSA': 'cryptojs/jsrsa',
+            'SHA224withECDSA': 'cryptojs/jsrsa',
+            'SHA256withECDSA': 'cryptojs/jsrsa',
+            'SHA384withECDSA': 'cryptojs/jsrsa',
+            'SHA512withECDSA': 'cryptojs/jsrsa',
+            'RIPEMD160withECDSA': 'cryptojs/jsrsa',
 
-        // for cryptojs
-        if (':md5:sha1:sha224:sha256:sha384:sha512:ripemd160:'.indexOf(hashAlg) !== -1 &&
-            prov === 'cryptojs') {
-            try {
-                var mdObj = KJUR.crypto.Util.CRYPTOJSMESSAGEDIGESTNAME[hashAlg];
-                this.mac = CryptoJS.algo.HMAC.create(mdObj, this.pass);
-            } catch (ex) {
-                throw "setAlgAndProvider hash alg set fail hashAlg=" + hashAlg + "/" + ex;
+            'SHA1withDSA': 'cryptojs/jsrsa',
+            'SHA224withDSA': 'cryptojs/jsrsa',
+            'SHA256withDSA': 'cryptojs/jsrsa',
+
+            'MD5withRSAandMGF1': 'cryptojs/jsrsa',
+            'SHA1withRSAandMGF1': 'cryptojs/jsrsa',
+            'SHA224withRSAandMGF1': 'cryptojs/jsrsa',
+            'SHA256withRSAandMGF1': 'cryptojs/jsrsa',
+            'SHA384withRSAandMGF1': 'cryptojs/jsrsa',
+            'SHA512withRSAandMGF1': 'cryptojs/jsrsa',
+            'RIPEMD160withRSAandMGF1': 'cryptojs/jsrsa',
+        },
+
+        /*
+         * @since crypto 1.1.2
+         */
+        CRYPTOJSMESSAGEDIGESTNAME: {
+            'md5': CryptoJS.algo.MD5,
+            'sha1': CryptoJS.algo.SHA1,
+            'sha224': CryptoJS.algo.SHA224,
+            'sha256': CryptoJS.algo.SHA256,
+            'sha384': CryptoJS.algo.SHA384,
+            'sha512': CryptoJS.algo.SHA512,
+            'ripemd160': CryptoJS.algo.RIPEMD160
+        },
+
+        /**
+         * get hexadecimal DigestInfo
+         * @name getDigestInfoHex
+         * @memberOf KJUR.crypto.Util
+         * @function
+         * @param {String} hHash hexadecimal hash value
+         * @param {String} alg hash algorithm name (ex. 'sha1')
+         * @return {String} hexadecimal string DigestInfo ASN.1 structure
+         */
+        getDigestInfoHex: function(hHash, alg) {
+            if (typeof this.DIGESTINFOHEAD[alg] === "undefined") {
+                throw "alg not supported in Util.DIGESTINFOHEAD: " + alg;
             }
-            this.updateString = function(str) {
-                this.mac.update(str);
-            };
-            this.updateHex = function(hex) {
-                var wHex = CryptoJS.enc.Hex.parse(hex);
-                this.mac.update(wHex);
-            };
-            this.doFinal = function() {
-                var hash = this.mac.finalize();
-                return hash.toString(CryptoJS.enc.Hex);
-            };
-            this.doFinalString = function(str) {
-                this.updateString(str);
-                return this.doFinal();
-            };
-            this.doFinalHex = function(hex) {
-                this.updateHex(hex);
-                return this.doFinal();
-            };
-        }
-    };
+            return this.DIGESTINFOHEAD[alg] + hHash;
+        },
 
-    /**
-     * update digest by specified string
-     * @name updateString
-     * @memberOf KJUR.crypto.Mac
-     * @function
-     * @param {String} str string to update
-     * @description
-     * @example
-     * md.updateString('New York');
-     */
-    this.updateString = function() {
-        throw "updateString(str) not supported for this alg/prov: " + this.algProv;
-    };
+        /**
+         * get PKCS#1 padded hexadecimal DigestInfo
+         * @name getPaddedDigestInfoHex
+         * @memberOf KJUR.crypto.Util
+         * @function
+         * @param {String} hHash hexadecimal hash value of message to be signed
+         * @param {String} alg hash algorithm name (ex. 'sha1')
+         * @param {Integer} keySize key bit length (ex. 1024)
+         * @return {String} hexadecimal string of PKCS#1 padded DigestInfo
+         */
+        getPaddedDigestInfoHex: function(hHash, alg, keySize) {
+            var hDigestInfo = this.getDigestInfoHex(hHash, alg);
+            var pmStrLen = keySize / 4; // minimum PM length
 
-    /**
-     * update digest by specified hexadecimal string
-     * @name updateHex
-     * @memberOf KJUR.crypto.Mac
-     * @function
-     * @param {String} hex hexadecimal string to update
-     * @description
-     * @example
-     * md.updateHex('0afe36');
-     */
-    this.updateHex = function() {
-        throw "updateHex(hex) not supported for this alg/prov: " + this.algProv;
-    };
-
-    /**
-     * completes hash calculation and returns hash result
-     * @name doFinal
-     * @memberOf KJUR.crypto.Mac
-     * @function
-     * @description
-     * @example
-     * md.digest()
-     */
-    this.doFinal = function() {
-        throw "digest() not supported for this alg/prov: " + this.algProv;
-    };
-
-    /**
-     * performs final update on the digest using string, then completes the digest computation
-     * @name doFinalString
-     * @memberOf KJUR.crypto.Mac
-     * @function
-     * @param {String} str string to final update
-     * @description
-     * @example
-     * md.digestString('aaa')
-     */
-    this.doFinalString = function() {
-        throw "digestString(str) not supported for this alg/prov: " + this.algProv;
-    };
-
-    /**
-     * performs final update on the digest using hexadecimal string,
-     * then completes the digest computation
-     * @name doFinalHex
-     * @memberOf KJUR.crypto.Mac
-     * @function
-     * @param {String} hex hexadecimal string to final update
-     * @description
-     * @example
-     * md.digestHex('0f2abd')
-     */
-    this.doFinalHex = function() {
-        throw "digestHex(hex) not supported for this alg/prov: " + this.algProv;
-    };
-
-    if (params !== undefined) {
-        if (params.pass !== undefined) {
-            this.pass = params.pass;
-        }
-        if (params.alg !== undefined) {
-            this.algName = params.alg;
-            if (params.prov === undefined) {
-                this.provName = KJUR.crypto.Util.DEFAULTPROVIDER[this.algName];
-            }
-            this.setAlgAndProvider(this.algName, this.provName);
-        }
-    }
-};
-
-/**
- * Signature class which is very similar to java.security.Signature class
- * @name KJUR.crypto.Signature
- * @class Signature class which is very similar to java.security.Signature class
- * @param {Array} params parameters for constructor
- * @property {String} state Current state of this signature object whether 'SIGN', 'VERIFY' or null
- * @description
- * <br/>
- * As for params of constructor's argument, it can be specify following attributes:
- * <ul>
- * <li>alg - signature algorithm name (ex. {MD5,SHA1,SHA224,SHA256,SHA384,SHA512,RIPEMD160}with{RSA,ECDSA,DSA})</li>
- * <li>provider - currently 'cryptojs/jsrsa' only</li>
- * </ul>
- * <h4>SUPPORTED ALGORITHMS AND PROVIDERS</h4>
- * This Signature class supports following signature algorithm and provider names:
- * <ul>
- * <li>MD5withRSA - cryptojs/jsrsa</li>
- * <li>SHA1withRSA - cryptojs/jsrsa</li>
- * <li>SHA224withRSA - cryptojs/jsrsa</li>
- * <li>SHA256withRSA - cryptojs/jsrsa</li>
- * <li>SHA384withRSA - cryptojs/jsrsa</li>
- * <li>SHA512withRSA - cryptojs/jsrsa</li>
- * <li>RIPEMD160withRSA - cryptojs/jsrsa</li>
- * <li>MD5withECDSA - cryptojs/jsrsa</li>
- * <li>SHA1withECDSA - cryptojs/jsrsa</li>
- * <li>SHA224withECDSA - cryptojs/jsrsa</li>
- * <li>SHA256withECDSA - cryptojs/jsrsa</li>
- * <li>SHA384withECDSA - cryptojs/jsrsa</li>
- * <li>SHA512withECDSA - cryptojs/jsrsa</li>
- * <li>RIPEMD160withECDSA - cryptojs/jsrsa</li>
- * <li>MD5withRSAandMGF1 - cryptojs/jsrsa</li>
- * <li>SHA1withRSAandMGF1 - cryptojs/jsrsa</li>
- * <li>SHA224withRSAandMGF1 - cryptojs/jsrsa</li>
- * <li>SHA256withRSAandMGF1 - cryptojs/jsrsa</li>
- * <li>SHA384withRSAandMGF1 - cryptojs/jsrsa</li>
- * <li>SHA512withRSAandMGF1 - cryptojs/jsrsa</li>
- * <li>RIPEMD160withRSAandMGF1 - cryptojs/jsrsa</li>
- * <li>SHA1withDSA - cryptojs/jsrsa</li>
- * <li>SHA224withDSA - cryptojs/jsrsa</li>
- * <li>SHA256withDSA - cryptojs/jsrsa</li>
- * </ul>
- * Here are supported elliptic cryptographic curve names and their aliases for ECDSA:
- * <ul>
- * <li>secp256k1</li>
- * <li>secp256r1, NIST P-256, P-256, prime256v1</li>
- * <li>secp384r1, NIST P-384, P-384</li>
- * </ul>
- * NOTE1: DSA signing algorithm is also supported since crypto 1.1.5.
- * <h4>EXAMPLES</h4>
- * @example
- * // RSA signature generation
- * var sig = new KJUR.crypto.Signature({"alg": "SHA1withRSA"});
- * sig.init(prvKeyPEM);
- * sig.updateString('aaa');
- * var hSigVal = sig.sign();
- *
- * // DSA signature validation
- * var sig2 = new KJUR.crypto.Signature({"alg": "SHA1withDSA"});
- * sig2.init(certPEM);
- * sig.updateString('aaa');
- * var isValid = sig2.verify(hSigVal);
- *
- * // ECDSA signing
- * var sig = new KJUR.crypto.Signature({'alg':'SHA1withECDSA'});
- * sig.init(prvKeyPEM);
- * sig.updateString('aaa');
- * var sigValueHex = sig.sign();
- *
- * // ECDSA verifying
- * var sig2 = new KJUR.crypto.Signature({'alg':'SHA1withECDSA'});
- * sig.init(certPEM);
- * sig.updateString('aaa');
- * var isValid = sig.verify(sigValueHex);
- */
-KJUR.crypto.Signature = function(params) {
-    var prvKey = null; // RSAKey/KJUR.crypto.{ECDSA,DSA} object for signing
-
-    this._setAlgNames = function() {
-        if (this.algName.match(/^(.+)with(.+)$/)) {
-            this.mdAlgName = RegExp.$1.toLowerCase();
-            this.pubkeyAlgName = RegExp.$2.toLowerCase();
-        }
-    };
-
-    this._zeroPaddingOfSignature = function(hex, bitLength) {
-        var s = "";
-        var nZero = bitLength / 4 - hex.length;
-        for (var i = 0; i < nZero; i += 1) {
-            s = s + "0";
-        }
-        return s + hex;
-    };
-
-    /**
-     * set signature algorithm and provider
-     * @name setAlgAndProvider
-     * @memberOf KJUR.crypto.Signature
-     * @function
-     * @param {String} alg signature algorithm name
-     * @param {String} prov provider name
-     * @description
-     * @example
-     * md.setAlgAndProvider('SHA1withRSA', 'cryptojs/jsrsa');
-     */
-    this.setAlgAndProvider = function(alg, prov) {
-        this._setAlgNames();
-        if (prov !== 'cryptojs/jsrsa') {
-            throw "provider not supported: " + prov;
-        }
-
-        if (':md5:sha1:sha224:sha256:sha384:sha512:ripemd160:'.indexOf(this.mdAlgName) !== -1) {
-            try {
-                this.md = new KJUR.crypto.MessageDigest({
-                    'alg': this.mdAlgName
-                });
-            } catch (ex) {
-                throw "setAlgAndProvider hash alg set fail alg=" +
-                this.mdAlgName + "/" + ex;
+            if ( // len(0001+ff(*8)+00+hDigestInfo)=22
+                hDigestInfo.length + 22 > pmStrLen) {
+                throw "key is too short for SigAlg: keylen=" + keySize + "," + alg;
             }
 
-            this.init = function(keyparam, pass) {
-                var keyObj = null;
+            var hHead = "0001";
+            var hTail = "00" + hDigestInfo;
+            var hMid = "";
+            var fLen = pmStrLen - hHead.length - hTail.length;
+            for (var i = 0; i < fLen; i += 2) {
+                hMid += "ff";
+            }
+            var hPaddedMessage = hHead + hMid + hTail;
+            return hPaddedMessage;
+        },
+
+        /**
+         * get hexadecimal hash of string with specified algorithm
+         * @name hashString
+         * @memberOf KJUR.crypto.Util
+         * @function
+         * @param {String} s input string to be hashed
+         * @param {String} alg hash algorithm name
+         * @return {String} hexadecimal string of hash value
+         * @since 1.1.1
+         */
+        hashString: function(s, alg) {
+            var md = new KJUR.crypto.MessageDigest({
+                'alg': alg
+            });
+            return md.digestString(s);
+        },
+
+        /**
+         * get hexadecimal hash of hexadecimal string with specified algorithm
+         * @name hashHex
+         * @memberOf KJUR.crypto.Util
+         * @function
+         * @param {String} sHex input hexadecimal string to be hashed
+         * @param {String} alg hash algorithm name
+         * @return {String} hexadecimal string of hash value
+         * @since 1.1.1
+         */
+        hashHex: function(sHex, alg) {
+            var md = new KJUR.crypto.MessageDigest({
+                'alg': alg
+            });
+            return md.digestHex(sHex);
+        },
+
+        /**
+         * get hexadecimal SHA1 hash of string
+         * @name sha1
+         * @memberOf KJUR.crypto.Util
+         * @function
+         * @param {String} s input string to be hashed
+         * @return {String} hexadecimal string of hash value
+         * @since 1.0.3
+         */
+        sha1: function(s) {
+            var md = new KJUR.crypto.MessageDigest({
+                'alg': 'sha1',
+                'prov': 'cryptojs'
+            });
+            return md.digestString(s);
+        },
+
+        /**
+         * get hexadecimal SHA256 hash of string
+         * @name sha256
+         * @memberOf KJUR.crypto.Util
+         * @function
+         * @param {String} s input string to be hashed
+         * @return {String} hexadecimal string of hash value
+         * @since 1.0.3
+         */
+        sha256: function(s) {
+            var md = new KJUR.crypto.MessageDigest({
+                'alg': 'sha256',
+                'prov': 'cryptojs'
+            });
+            return md.digestString(s);
+        },
+
+        sha256Hex: function(s) {
+            var md = new KJUR.crypto.MessageDigest({
+                'alg': 'sha256',
+                'prov': 'cryptojs'
+            });
+            return md.digestHex(s);
+        },
+
+        /**
+         * get hexadecimal SHA512 hash of string
+         * @name sha512
+         * @memberOf KJUR.crypto.Util
+         * @function
+         * @param {String} s input string to be hashed
+         * @return {String} hexadecimal string of hash value
+         * @since 1.0.3
+         */
+        sha512: function(s) {
+            var md = new KJUR.crypto.MessageDigest({
+                'alg': 'sha512',
+                'prov': 'cryptojs'
+            });
+            return md.digestString(s);
+        },
+
+        sha512Hex: function(s) {
+            var md = new KJUR.crypto.MessageDigest({
+                'alg': 'sha512',
+                'prov': 'cryptojs'
+            });
+            return md.digestHex(s);
+        },
+
+        /**
+         * get hexadecimal MD5 hash of string
+         * @name md5
+         * @memberOf KJUR.crypto.Util
+         * @function
+         * @param {String} s input string to be hashed
+         * @return {String} hexadecimal string of hash value
+         * @since 1.0.3
+         */
+        md5: function(s) {
+            var md = new KJUR.crypto.MessageDigest({
+                'alg': 'md5',
+                'prov': 'cryptojs'
+            });
+            return md.digestString(s);
+        },
+
+        /**
+         * get hexadecimal RIPEMD160 hash of string
+         * @name ripemd160
+         * @memberOf KJUR.crypto.Util
+         * @function
+         * @param {String} s input string to be hashed
+         * @return {String} hexadecimal string of hash value
+         * @since 1.0.3
+         */
+        ripemd160: function(s) {
+            var md = new KJUR.crypto.MessageDigest({
+                'alg': 'ripemd160',
+                'prov': 'cryptojs'
+            });
+            return md.digestString(s);
+        }
+    };
+
+    /**
+     * MessageDigest class which is very similar to java.security.MessageDigest class
+     * @name KJUR.crypto.MessageDigest
+     * @class MessageDigest class which is very similar to java.security.MessageDigest class
+     * @param {Array} params parameters for constructor
+     * @description
+     * <br/>
+     * Currently this supports following algorithm and providers combination:
+     * <ul>
+     * <li>md5 - cryptojs</li>
+     * <li>sha1 - cryptojs</li>
+     * <li>sha224 - cryptojs</li>
+     * <li>sha256 - cryptojs</li>
+     * <li>sha384 - cryptojs</li>
+     * <li>sha512 - cryptojs</li>
+     * <li>ripemd160 - cryptojs</li>
+     * <li>sha256 - sjcl (NEW from crypto.js 1.0.4)</li>
+     * </ul>
+     * @example
+     * // CryptoJS provider sample
+     * &lt;script src="http://crypto-js.googlecode.com/svn/tags/3.1.2/build/components/core.js"&gt;&lt;/script&gt;
+     * &lt;script src="http://crypto-js.googlecode.com/svn/tags/3.1.2/build/components/sha1.js"&gt;&lt;/script&gt;
+     * &lt;script src="crypto-1.0.js"&gt;&lt;/script&gt;
+     * var md = new KJUR.crypto.MessageDigest({alg: "sha1", prov: "cryptojs"});
+     * md.updateString('aaa')
+     * var mdHex = md.digest()
+     *
+     * // SJCL(Stanford JavaScript Crypto Library) provider sample
+     * &lt;script src="http://bitwiseshiftleft.github.io/sjcl/sjcl.js"&gt;&lt;/script&gt;
+     * &lt;script src="crypto-1.0.js"&gt;&lt;/script&gt;
+     * var md = new KJUR.crypto.MessageDigest({alg: "sha256", prov: "sjcl"}); // sjcl supports sha256 only
+     * md.updateString('aaa')
+     * var mdHex = md.digest()
+     */
+    KJUR.crypto.MessageDigest = function(params) {
+        /**
+         * set hash algorithm and provider
+         * @name setAlgAndProvider
+         * @memberOf KJUR.crypto.MessageDigest
+         * @function
+         * @param {String} alg hash algorithm name
+         * @param {String} prov provider name
+         * @description
+         * @example
+         * // for SHA1
+         * md.setAlgAndProvider('sha1', 'cryptojs');
+         * // for RIPEMD160
+         * md.setAlgAndProvider('ripemd160', 'cryptojs');
+         */
+        this.setAlgAndProvider = function(alg, prov) {
+            if (alg !== null && prov === undefined) {
+                prov = KJUR.crypto.Util.DEFAULTPROVIDER[alg];
+            }
+
+            // for cryptojs
+            if (':md5:sha1:sha224:sha256:sha384:sha512:ripemd160:'.indexOf(alg) !== -1 &&
+                prov === 'cryptojs') {
                 try {
-                    if (pass === undefined) {
-                        keyObj = KEYUTIL.getKey(keyparam);
-                    } else {
-                        keyObj = KEYUTIL.getKey(keyparam, pass);
-                    }
+                    this.md = KJUR.crypto.Util.CRYPTOJSMESSAGEDIGESTNAME[alg].create();
                 } catch (ex) {
-                    throw "init failed:" + ex;
+                    throw "setAlgAndProvider hash alg set fail alg=" + alg + "/" + ex;
                 }
-
-                if (keyObj.isPrivate === true) {
-                    this.prvKey = keyObj;
-                    this.state = "SIGN";
-                } else if (keyObj.isPublic === true) {
-                    this.pubKey = keyObj;
-                    this.state = "VERIFY";
-                } else {
-                    throw "init failed.:" + keyObj;
+                this.updateString = function(str) {
+                    this.md.update(str);
+                };
+                this.updateHex = function(hex) {
+                    var wHex = CryptoJS.enc.Hex.parse(hex);
+                    this.md.update(wHex);
+                };
+                this.digest = function() {
+                    var hash = this.md.finalize();
+                    return hash.toString(CryptoJS.enc.Hex);
+                };
+                this.digestString = function(str) {
+                    this.updateString(str);
+                    return this.digest();
+                };
+                this.digestHex = function(hex) {
+                    this.updateHex(hex);
+                    return this.digest();
+                };
+            }
+            if (':sha256:'.indexOf(alg) !== -1 &&
+                prov === 'sjcl') {
+                try {
+                    this.md = new sjcl.hash.sha256();
+                } catch (ex) {
+                    throw "setAlgAndProvider hash alg set fail alg=" + alg + "/" + ex;
                 }
-            };
+                this.updateString = function(str) {
+                    this.md.update(str);
+                };
+                this.updateHex = function(hex) {
+                    var baHex = sjcl.codec.hex.toBits(hex);
+                    this.md.update(baHex);
+                };
+                this.digest = function() {
+                    var hash = this.md.finalize();
+                    return sjcl.codec.hex.fromBits(hash);
+                };
+                this.digestString = function(str) {
+                    this.updateString(str);
+                    return this.digest();
+                };
+                this.digestHex = function(hex) {
+                    this.updateHex(hex);
+                    return this.digest();
+                };
+            }
+        };
 
-            this.initSign = function(params) {
-                if (typeof params.ecprvhex === 'string' &&
-                    typeof params.eccurvename === 'string') {
-                    this.ecprvhex = params.ecprvhex;
-                    this.eccurvename = params.eccurvename;
-                } else {
-                    this.prvKey = params;
+        /**
+         * update digest by specified string
+         * @name updateString
+         * @memberOf KJUR.crypto.MessageDigest
+         * @function
+         * @param {String} str string to update
+         * @description
+         * @example
+         * md.updateString('New York');
+         */
+        this.updateString = function() {
+            throw "updateString(str) not supported for this alg/prov: " + this.algName + "/" + this.provName;
+        };
+
+        /**
+         * update digest by specified hexadecimal string
+         * @name updateHex
+         * @memberOf KJUR.crypto.MessageDigest
+         * @function
+         * @param {String} hex hexadecimal string to update
+         * @description
+         * @example
+         * md.updateHex('0afe36');
+         */
+        this.updateHex = function() {
+            throw "updateHex(hex) not supported for this alg/prov: " + this.algName + "/" + this.provName;
+        };
+
+        /**
+         * completes hash calculation and returns hash result
+         * @name digest
+         * @memberOf KJUR.crypto.MessageDigest
+         * @function
+         * @description
+         * @example
+         * md.digest()
+         */
+        this.digest = function() {
+            throw "digest() not supported for this alg/prov: " + this.algName + "/" + this.provName;
+        };
+
+        /**
+         * performs final update on the digest using string, then completes the digest computation
+         * @name digestString
+         * @memberOf KJUR.crypto.MessageDigest
+         * @function
+         * @param {String} str string to final update
+         * @description
+         * @example
+         * md.digestString('aaa')
+         */
+        this.digestString = function() {
+            throw "digestString(str) not supported for this alg/prov: " + this.algName + "/" + this.provName;
+        };
+
+        /**
+         * performs final update on the digest using hexadecimal string, then completes the digest computation
+         * @name digestHex
+         * @memberOf KJUR.crypto.MessageDigest
+         * @function
+         * @param {String} hex hexadecimal string to final update
+         * @description
+         * @example
+         * md.digestHex('0f2abd')
+         */
+        this.digestHex = function() {
+            throw "digestHex(hex) not supported for this alg/prov: " + this.algName + "/" + this.provName;
+        };
+
+        if (params !== undefined) {
+            if (params.alg !== undefined) {
+                this.algName = params.alg;
+                if (params.prov === undefined) {
+                    this.provName = KJUR.crypto.Util.DEFAULTPROVIDER[this.algName];
                 }
-                this.state = "SIGN";
-            };
-
-            this.initVerifyByPublicKey = function(params) {
-                if (typeof params.ecpubhex === 'string' &&
-                    typeof params.eccurvename === 'string') {
-                    this.ecpubhex = params.ecpubhex;
-                    this.eccurvename = params.eccurvename;
-                } else if (params instanceof KJUR.crypto.ECDSA) {
-                    this.pubKey = params;
-                } else if (params instanceof RSAKey) {
-                    this.pubKey = params;
-                }
-                this.state = "VERIFY";
-            };
-
-            this.initVerifyByCertificatePEM = function(certPEM) {
-                var x509 = new X509();
-                x509.readCertPEM(certPEM);
-                this.pubKey = x509.subjectPublicKeyRSA;
-                this.state = "VERIFY";
-            };
-
-            this.updateString = function(str) {
-                this.md.updateString(str);
-            };
-            this.updateHex = function(hex) {
-                this.md.updateHex(hex);
-            };
-
-            this.sign = function() {
-                this.sHashHex = this.md.digest();
-                if (typeof this.ecprvhex !== "undefined" &&
-                    typeof this.eccurvename !== "undefined") {
-                    var ec = new KJUR.crypto.ECDSA({
-                        'curve': this.eccurvename
-                    });
-                    this.hSign = ec.signHex(this.sHashHex, this.ecprvhex);
-                } else if (this.pubkeyAlgName === "rsaandmgf1") {
-                    this.hSign = this.prvKey.signWithMessageHashPSS(this.sHashHex,
-                        this.mdAlgName,
-                        this.pssSaltLen);
-                } else if (this.pubkeyAlgName === "rsa") {
-                    this.hSign = this.prvKey.signWithMessageHash(this.sHashHex,
-                        this.mdAlgName);
-                } else if (this.prvKey instanceof KJUR.crypto.ECDSA) {
-                    this.hSign = this.prvKey.signWithMessageHash(this.sHashHex);
-                } else if (this.prvKey instanceof KJUR.crypto.DSA) {
-                    this.hSign = this.prvKey.signWithMessageHash(this.sHashHex);
-                } else {
-                    throw "Signature: unsupported public key alg: " + this.pubkeyAlgName;
-                }
-                return this.hSign;
-            };
-            this.signString = function(str) {
-                this.updateString(str);
-                return this.sign();
-            };
-            this.signHex = function(hex) {
-                this.updateHex(hex);
-                return this.sign();
-            };
-            this.verify = function(hSigVal) {
-                this.sHashHex = this.md.digest();
-                if (typeof this.ecpubhex !== "undefined" &&
-                    typeof this.eccurvename !== "undefined") {
-                    var ec = new KJUR.crypto.ECDSA({
-                        curve: this.eccurvename
-                    });
-                    return ec.verifyHex(this.sHashHex, hSigVal, this.ecpubhex);
-                } else if (this.pubkeyAlgName === "rsaandmgf1") {
-                    return this.pubKey.verifyWithMessageHashPSS(this.sHashHex, hSigVal,
-                        this.mdAlgName,
-                        this.pssSaltLen);
-                } else if (this.pubkeyAlgName === "rsa") {
-                    return this.pubKey.verifyWithMessageHash(this.sHashHex, hSigVal);
-                } else if (this.pubKey instanceof KJUR.crypto.ECDSA) {
-                    return this.pubKey.verifyWithMessageHash(this.sHashHex, hSigVal);
-                } else if (this.pubKey instanceof KJUR.crypto.DSA) {
-                    return this.pubKey.verifyWithMessageHash(this.sHashHex, hSigVal);
-                } else {
-                    throw "Signature: unsupported public key alg: " + this.pubkeyAlgName;
-                }
-            };
+                this.setAlgAndProvider(this.algName, this.provName);
+            }
         }
     };
 
     /**
-     * Initialize this object for signing or verifying depends on key
-     * @name init
-     * @memberOf KJUR.crypto.Signature
-     * @function
-     * @param {Object} key specifying public or private key as plain/encrypted PKCS#5/8 PEM file, certificate PEM or {@link RSAKey}, {@link KJUR.crypto.DSA} or {@link KJUR.crypto.ECDSA} object
-     * @param {String} pass (OPTION) passcode for encrypted private key
+     * Mac(Message Authentication Code) class which is very similar to java.security.Mac class
+     * @name KJUR.crypto.Mac
+     * @class Mac class which is very similar to java.security.Mac class
+     * @param {Array} params parameters for constructor
+     * @description
+     * <br/>
+     * Currently this supports following algorithm and providers combination:
+     * <ul>
+     * <li>hmacmd5 - cryptojs</li>
+     * <li>hmacsha1 - cryptojs</li>
+     * <li>hmacsha224 - cryptojs</li>
+     * <li>hmacsha256 - cryptojs</li>
+     * <li>hmacsha384 - cryptojs</li>
+     * <li>hmacsha512 - cryptojs</li>
+     * </ul>
+     * NOTE: HmacSHA224 and HmacSHA384 issue was fixed since jsrsasign 4.1.4.
+     * Please use 'ext/cryptojs-312-core-fix*.js' instead of 'core.js' of original CryptoJS
+     * to avoid those issue.
+     * @example
+     * var mac = new KJUR.crypto.Mac({alg: "HmacSHA1", prov: "cryptojs", "pass": "pass"});
+     * mac.updateString('aaa')
+     * var macHex = md.doFinal()
+     */
+    KJUR.crypto.Mac = function(params) {
+        this.setAlgAndProvider = function(alg, prov) {
+            if (alg === null) {
+                alg = "hmacsha1";
+            }
+
+            alg = alg.toLowerCase();
+            if (alg.substr(0, 4) !== "hmac") {
+                throw "setAlgAndProvider unsupported HMAC alg: " + alg;
+            }
+
+            if (prov === undefined) {
+                prov = KJUR.crypto.Util.DEFAULTPROVIDER[alg];
+            }
+            this.algProv = alg + "/" + prov;
+
+            var hashAlg = alg.substr(4);
+
+            // for cryptojs
+            if (':md5:sha1:sha224:sha256:sha384:sha512:ripemd160:'.indexOf(hashAlg) !== -1 &&
+                prov === 'cryptojs') {
+                try {
+                    var mdObj = KJUR.crypto.Util.CRYPTOJSMESSAGEDIGESTNAME[hashAlg];
+                    this.mac = CryptoJS.algo.HMAC.create(mdObj, this.pass);
+                } catch (ex) {
+                    throw "setAlgAndProvider hash alg set fail hashAlg=" + hashAlg + "/" + ex;
+                }
+                this.updateString = function(str) {
+                    this.mac.update(str);
+                };
+                this.updateHex = function(hex) {
+                    var wHex = CryptoJS.enc.Hex.parse(hex);
+                    this.mac.update(wHex);
+                };
+                this.doFinal = function() {
+                    var hash = this.mac.finalize();
+                    return hash.toString(CryptoJS.enc.Hex);
+                };
+                this.doFinalString = function(str) {
+                    this.updateString(str);
+                    return this.doFinal();
+                };
+                this.doFinalHex = function(hex) {
+                    this.updateHex(hex);
+                    return this.doFinal();
+                };
+            }
+        };
+
+        /**
+         * update digest by specified string
+         * @name updateString
+         * @memberOf KJUR.crypto.Mac
+         * @function
+         * @param {String} str string to update
+         * @description
+         * @example
+         * md.updateString('New York');
+         */
+        this.updateString = function() {
+            throw "updateString(str) not supported for this alg/prov: " + this.algProv;
+        };
+
+        /**
+         * update digest by specified hexadecimal string
+         * @name updateHex
+         * @memberOf KJUR.crypto.Mac
+         * @function
+         * @param {String} hex hexadecimal string to update
+         * @description
+         * @example
+         * md.updateHex('0afe36');
+         */
+        this.updateHex = function() {
+            throw "updateHex(hex) not supported for this alg/prov: " + this.algProv;
+        };
+
+        /**
+         * completes hash calculation and returns hash result
+         * @name doFinal
+         * @memberOf KJUR.crypto.Mac
+         * @function
+         * @description
+         * @example
+         * md.digest()
+         */
+        this.doFinal = function() {
+            throw "digest() not supported for this alg/prov: " + this.algProv;
+        };
+
+        /**
+         * performs final update on the digest using string, then completes the digest computation
+         * @name doFinalString
+         * @memberOf KJUR.crypto.Mac
+         * @function
+         * @param {String} str string to final update
+         * @description
+         * @example
+         * md.digestString('aaa')
+         */
+        this.doFinalString = function() {
+            throw "digestString(str) not supported for this alg/prov: " + this.algProv;
+        };
+
+        /**
+         * performs final update on the digest using hexadecimal string,
+         * then completes the digest computation
+         * @name doFinalHex
+         * @memberOf KJUR.crypto.Mac
+         * @function
+         * @param {String} hex hexadecimal string to final update
+         * @description
+         * @example
+         * md.digestHex('0f2abd')
+         */
+        this.doFinalHex = function() {
+            throw "digestHex(hex) not supported for this alg/prov: " + this.algProv;
+        };
+
+        if (params !== undefined) {
+            if (params.pass !== undefined) {
+                this.pass = params.pass;
+            }
+            if (params.alg !== undefined) {
+                this.algName = params.alg;
+                if (params.prov === undefined) {
+                    this.provName = KJUR.crypto.Util.DEFAULTPROVIDER[this.algName];
+                }
+                this.setAlgAndProvider(this.algName, this.provName);
+            }
+        }
+    };
+
+    /**
+     * Signature class which is very similar to java.security.Signature class
+     * @name KJUR.crypto.Signature
+     * @class Signature class which is very similar to java.security.Signature class
+     * @param {Array} params parameters for constructor
+     * @property {String} state Current state of this signature object whether 'SIGN', 'VERIFY' or null
+     * @description
+     * <br/>
+     * As for params of constructor's argument, it can be specify following attributes:
+     * <ul>
+     * <li>alg - signature algorithm name (ex. {MD5,SHA1,SHA224,SHA256,SHA384,SHA512,RIPEMD160}with{RSA,ECDSA,DSA})</li>
+     * <li>provider - currently 'cryptojs/jsrsa' only</li>
+     * </ul>
+     * <h4>SUPPORTED ALGORITHMS AND PROVIDERS</h4>
+     * This Signature class supports following signature algorithm and provider names:
+     * <ul>
+     * <li>MD5withRSA - cryptojs/jsrsa</li>
+     * <li>SHA1withRSA - cryptojs/jsrsa</li>
+     * <li>SHA224withRSA - cryptojs/jsrsa</li>
+     * <li>SHA256withRSA - cryptojs/jsrsa</li>
+     * <li>SHA384withRSA - cryptojs/jsrsa</li>
+     * <li>SHA512withRSA - cryptojs/jsrsa</li>
+     * <li>RIPEMD160withRSA - cryptojs/jsrsa</li>
+     * <li>MD5withECDSA - cryptojs/jsrsa</li>
+     * <li>SHA1withECDSA - cryptojs/jsrsa</li>
+     * <li>SHA224withECDSA - cryptojs/jsrsa</li>
+     * <li>SHA256withECDSA - cryptojs/jsrsa</li>
+     * <li>SHA384withECDSA - cryptojs/jsrsa</li>
+     * <li>SHA512withECDSA - cryptojs/jsrsa</li>
+     * <li>RIPEMD160withECDSA - cryptojs/jsrsa</li>
+     * <li>MD5withRSAandMGF1 - cryptojs/jsrsa</li>
+     * <li>SHA1withRSAandMGF1 - cryptojs/jsrsa</li>
+     * <li>SHA224withRSAandMGF1 - cryptojs/jsrsa</li>
+     * <li>SHA256withRSAandMGF1 - cryptojs/jsrsa</li>
+     * <li>SHA384withRSAandMGF1 - cryptojs/jsrsa</li>
+     * <li>SHA512withRSAandMGF1 - cryptojs/jsrsa</li>
+     * <li>RIPEMD160withRSAandMGF1 - cryptojs/jsrsa</li>
+     * <li>SHA1withDSA - cryptojs/jsrsa</li>
+     * <li>SHA224withDSA - cryptojs/jsrsa</li>
+     * <li>SHA256withDSA - cryptojs/jsrsa</li>
+     * </ul>
+     * Here are supported elliptic cryptographic curve names and their aliases for ECDSA:
+     * <ul>
+     * <li>secp256k1</li>
+     * <li>secp256r1, NIST P-256, P-256, prime256v1</li>
+     * <li>secp384r1, NIST P-384, P-384</li>
+     * </ul>
+     * NOTE1: DSA signing algorithm is also supported since crypto 1.1.5.
+     * <h4>EXAMPLES</h4>
+     * @example
+     * // RSA signature generation
+     * var sig = new KJUR.crypto.Signature({"alg": "SHA1withRSA"});
+     * sig.init(prvKeyPEM);
+     * sig.updateString('aaa');
+     * var hSigVal = sig.sign();
+     *
+     * // DSA signature validation
+     * var sig2 = new KJUR.crypto.Signature({"alg": "SHA1withDSA"});
+     * sig2.init(certPEM);
+     * sig.updateString('aaa');
+     * var isValid = sig2.verify(hSigVal);
+     *
+     * // ECDSA signing
+     * var sig = new KJUR.crypto.Signature({'alg':'SHA1withECDSA'});
+     * sig.init(prvKeyPEM);
+     * sig.updateString('aaa');
+     * var sigValueHex = sig.sign();
+     *
+     * // ECDSA verifying
+     * var sig2 = new KJUR.crypto.Signature({'alg':'SHA1withECDSA'});
+     * sig.init(certPEM);
+     * sig.updateString('aaa');
+     * var isValid = sig.verify(sigValueHex);
+     */
+    KJUR.crypto.Signature = function(params) {
+        var prvKey = null; // RSAKey/KJUR.crypto.{ECDSA,DSA} object for signing
+
+        this._setAlgNames = function() {
+            if (this.algName.match(/^(.+)with(.+)$/)) {
+                this.mdAlgName = RegExp.$1.toLowerCase();
+                this.pubkeyAlgName = RegExp.$2.toLowerCase();
+            }
+        };
+
+        this._zeroPaddingOfSignature = function(hex, bitLength) {
+            var s = "";
+            var nZero = bitLength / 4 - hex.length;
+            for (var i = 0; i < nZero; i += 1) {
+                s = s + "0";
+            }
+            return s + hex;
+        };
+
+        /**
+         * set signature algorithm and provider
+         * @name setAlgAndProvider
+         * @memberOf KJUR.crypto.Signature
+         * @function
+         * @param {String} alg signature algorithm name
+         * @param {String} prov provider name
+         * @description
+         * @example
+         * md.setAlgAndProvider('SHA1withRSA', 'cryptojs/jsrsa');
+         */
+        this.setAlgAndProvider = function(alg, prov) {
+            this._setAlgNames();
+            if (prov !== 'cryptojs/jsrsa') {
+                throw "provider not supported: " + prov;
+            }
+
+            if (':md5:sha1:sha224:sha256:sha384:sha512:ripemd160:'.indexOf(this.mdAlgName) !== -1) {
+                try {
+                    this.md = new KJUR.crypto.MessageDigest({
+                        'alg': this.mdAlgName
+                    });
+                } catch (ex) {
+                    throw "setAlgAndProvider hash alg set fail alg=" +
+                    this.mdAlgName + "/" + ex;
+                }
+
+                this.init = function(keyparam, pass) {
+                    var keyObj = null;
+                    try {
+                        if (pass === undefined) {
+                            keyObj = KEYUTIL.getKey(keyparam);
+                        } else {
+                            keyObj = KEYUTIL.getKey(keyparam, pass);
+                        }
+                    } catch (ex) {
+                        throw "init failed:" + ex;
+                    }
+
+                    if (keyObj.isPrivate === true) {
+                        this.prvKey = keyObj;
+                        this.state = "SIGN";
+                    } else if (keyObj.isPublic === true) {
+                        this.pubKey = keyObj;
+                        this.state = "VERIFY";
+                    } else {
+                        throw "init failed.:" + keyObj;
+                    }
+                };
+
+                this.initSign = function(params) {
+                    if (typeof params.ecprvhex === 'string' &&
+                        typeof params.eccurvename === 'string') {
+                        this.ecprvhex = params.ecprvhex;
+                        this.eccurvename = params.eccurvename;
+                    } else {
+                        this.prvKey = params;
+                    }
+                    this.state = "SIGN";
+                };
+
+                this.initVerifyByPublicKey = function(params) {
+                    if (typeof params.ecpubhex === 'string' &&
+                        typeof params.eccurvename === 'string') {
+                        this.ecpubhex = params.ecpubhex;
+                        this.eccurvename = params.eccurvename;
+                    } else if (params instanceof KJUR.crypto.ECDSA) {
+                        this.pubKey = params;
+                    } else if (params instanceof RSAKey) {
+                        this.pubKey = params;
+                    }
+                    this.state = "VERIFY";
+                };
+
+                this.initVerifyByCertificatePEM = function(certPEM) {
+                    var x509 = new X509();
+                    x509.readCertPEM(certPEM);
+                    this.pubKey = x509.subjectPublicKeyRSA;
+                    this.state = "VERIFY";
+                };
+
+                this.updateString = function(str) {
+                    this.md.updateString(str);
+                };
+                this.updateHex = function(hex) {
+                    this.md.updateHex(hex);
+                };
+
+                this.sign = function() {
+                    this.sHashHex = this.md.digest();
+                    if (typeof this.ecprvhex !== "undefined" &&
+                        typeof this.eccurvename !== "undefined") {
+                        var ec = new KJUR.crypto.ECDSA({
+                            'curve': this.eccurvename
+                        });
+                        this.hSign = ec.signHex(this.sHashHex, this.ecprvhex);
+                    } else if (this.pubkeyAlgName === "rsaandmgf1") {
+                        this.hSign = this.prvKey.signWithMessageHashPSS(this.sHashHex,
+                            this.mdAlgName,
+                            this.pssSaltLen);
+                    } else if (this.pubkeyAlgName === "rsa") {
+                        this.hSign = this.prvKey.signWithMessageHash(this.sHashHex,
+                            this.mdAlgName);
+                    } else if (this.prvKey instanceof KJUR.crypto.ECDSA) {
+                        this.hSign = this.prvKey.signWithMessageHash(this.sHashHex);
+                    } else if (this.prvKey instanceof KJUR.crypto.DSA) {
+                        this.hSign = this.prvKey.signWithMessageHash(this.sHashHex);
+                    } else {
+                        throw "Signature: unsupported public key alg: " + this.pubkeyAlgName;
+                    }
+                    return this.hSign;
+                };
+                this.signString = function(str) {
+                    this.updateString(str);
+                    return this.sign();
+                };
+                this.signHex = function(hex) {
+                    this.updateHex(hex);
+                    return this.sign();
+                };
+                this.verify = function(hSigVal) {
+                    this.sHashHex = this.md.digest();
+                    if (typeof this.ecpubhex !== "undefined" &&
+                        typeof this.eccurvename !== "undefined") {
+                        var ec = new KJUR.crypto.ECDSA({
+                            curve: this.eccurvename
+                        });
+                        return ec.verifyHex(this.sHashHex, hSigVal, this.ecpubhex);
+                    } else if (this.pubkeyAlgName === "rsaandmgf1") {
+                        return this.pubKey.verifyWithMessageHashPSS(this.sHashHex, hSigVal,
+                            this.mdAlgName,
+                            this.pssSaltLen);
+                    } else if (this.pubkeyAlgName === "rsa") {
+                        return this.pubKey.verifyWithMessageHash(this.sHashHex, hSigVal);
+                    } else if (this.pubKey instanceof KJUR.crypto.ECDSA) {
+                        return this.pubKey.verifyWithMessageHash(this.sHashHex, hSigVal);
+                    } else if (this.pubKey instanceof KJUR.crypto.DSA) {
+                        return this.pubKey.verifyWithMessageHash(this.sHashHex, hSigVal);
+                    } else {
+                        throw "Signature: unsupported public key alg: " + this.pubkeyAlgName;
+                    }
+                };
+            }
+        };
+
+        /**
+         * Initialize this object for signing or verifying depends on key
+         * @name init
+         * @memberOf KJUR.crypto.Signature
+         * @function
+         * @param {Object} key specifying public or private key as plain/encrypted PKCS#5/8 PEM file, certificate PEM or {@link RSAKey}, {@link KJUR.crypto.DSA} or {@link KJUR.crypto.ECDSA} object
+         * @param {String} pass (OPTION) passcode for encrypted private key
+         * @since crypto 1.1.3
+         * @description
+         * This method is very useful initialize method for Signature class since
+         * you just specify key then this method will automatically initialize it
+         * using {@link KEYUTIL.getKey} method.
+         * As for 'key',  following argument type are supported:
+         * <h5>signing</h5>
+         * <ul>
+         * <li>PEM formatted PKCS#8 encrypted RSA/ECDSA private key concluding "BEGIN ENCRYPTED PRIVATE KEY"</li>
+         * <li>PEM formatted PKCS#5 encrypted RSA/DSA private key concluding "BEGIN RSA/DSA PRIVATE KEY" and ",ENCRYPTED"</li>
+         * <li>PEM formatted PKCS#8 plain RSA/ECDSA private key concluding "BEGIN PRIVATE KEY"</li>
+         * <li>PEM formatted PKCS#5 plain RSA/DSA private key concluding "BEGIN RSA/DSA PRIVATE KEY" without ",ENCRYPTED"</li>
+         * <li>RSAKey object of private key</li>
+         * <li>KJUR.crypto.ECDSA object of private key</li>
+         * <li>KJUR.crypto.DSA object of private key</li>
+         * </ul>
+         * <h5>verification</h5>
+         * <ul>
+         * <li>PEM formatted PKCS#8 RSA/EC/DSA public key concluding "BEGIN PUBLIC KEY"</li>
+         * <li>PEM formatted X.509 certificate with RSA/EC/DSA public key concluding
+         *     "BEGIN CERTIFICATE", "BEGIN X509 CERTIFICATE" or "BEGIN TRUSTED CERTIFICATE".</li>
+         * <li>RSAKey object of public key</li>
+         * <li>KJUR.crypto.ECDSA object of public key</li>
+         * <li>KJUR.crypto.DSA object of public key</li>
+         * </ul>
+         * @example
+         * sig.init(sCertPEM)
+         */
+        this.init = function() {
+            throw "init(key, pass) not supported for this alg:prov=" +
+            this.algProvName;
+        };
+
+        /**
+         * Initialize this object for verifying with a public key
+         * @name initVerifyByPublicKey
+         * @memberOf KJUR.crypto.Signature
+         * @function
+         * @param {Object} param RSAKey object of public key or associative array for ECDSA
+         * @since 1.0.2
+         * @deprecated from crypto 1.1.5. please use init() method instead.
+         * @description
+         * Public key information will be provided as 'param' parameter and the value will be
+         * following:
+         * <ul>
+         * <li>{@link RSAKey} object for RSA verification</li>
+         * <li>associative array for ECDSA verification
+         *     (ex. <code>{'ecpubhex': '041f..', 'eccurvename': 'secp256r1'}</code>)
+         * </li>
+         * </ul>
+         * @example
+         * sig.initVerifyByPublicKey(rsaPrvKey)
+         */
+        this.initVerifyByPublicKey = function() {
+            throw "initVerifyByPublicKey(rsaPubKeyy) not supported for this alg:prov=" +
+            this.algProvName;
+        };
+
+        /**
+         * Initialize this object for verifying with a certficate
+         * @name initVerifyByCertificatePEM
+         * @memberOf KJUR.crypto.Signature
+         * @function
+         * @param {String} certPEM PEM formatted string of certificate
+         * @since 1.0.2
+         * @deprecated from crypto 1.1.5. please use init() method instead.
+         * @description
+         * @example
+         * sig.initVerifyByCertificatePEM(certPEM)
+         */
+        this.initVerifyByCertificatePEM = function() {
+            throw "initVerifyByCertificatePEM(certPEM) not supported for this alg:prov=" +
+            this.algProvName;
+        };
+
+        /**
+         * Initialize this object for signing
+         * @name initSign
+         * @memberOf KJUR.crypto.Signature
+         * @function
+         * @param {Object} param RSAKey object of public key or associative array for ECDSA
+         * @deprecated from crypto 1.1.5. please use init() method instead.
+         * @description
+         * Private key information will be provided as 'param' parameter and the value will be
+         * following:
+         * <ul>
+         * <li>{@link RSAKey} object for RSA signing</li>
+         * <li>associative array for ECDSA signing
+         *     (ex. <code>{'ecprvhex': '1d3f..', 'eccurvename': 'secp256r1'}</code>)</li>
+         * </ul>
+         * @example
+         * sig.initSign(prvKey)
+         */
+        this.initSign = function() {
+            throw "initSign(prvKey) not supported for this alg:prov=" + this.algProvName;
+        };
+
+        /**
+         * Updates the data to be signed or verified by a string
+         * @name updateString
+         * @memberOf KJUR.crypto.Signature
+         * @function
+         * @param {String} str string to use for the update
+         * @description
+         * @example
+         * sig.updateString('aaa')
+         */
+        this.updateString = function() {
+            throw "updateString(str) not supported for this alg:prov=" + this.algProvName;
+        };
+
+        /**
+         * Updates the data to be signed or verified by a hexadecimal string
+         * @name updateHex
+         * @memberOf KJUR.crypto.Signature
+         * @function
+         * @param {String} hex hexadecimal string to use for the update
+         * @description
+         * @example
+         * sig.updateHex('1f2f3f')
+         */
+        this.updateHex = function() {
+            throw "updateHex(hex) not supported for this alg:prov=" + this.algProvName;
+        };
+
+        /**
+         * Returns the signature bytes of all data updates as a hexadecimal string
+         * @name sign
+         * @memberOf KJUR.crypto.Signature
+         * @function
+         * @return the signature bytes as a hexadecimal string
+         * @description
+         * @example
+         * var hSigValue = sig.sign()
+         */
+        this.sign = function() {
+            throw "sign() not supported for this alg:prov=" + this.algProvName;
+        };
+
+        /**
+         * performs final update on the sign using string, then returns the signature bytes of all data updates as a hexadecimal string
+         * @name signString
+         * @memberOf KJUR.crypto.Signature
+         * @function
+         * @param {String} str string to final update
+         * @return the signature bytes of a hexadecimal string
+         * @description
+         * @example
+         * var hSigValue = sig.signString('aaa')
+         */
+        this.signString = function() {
+            throw "digestString(str) not supported for this alg:prov=" + this.algProvName;
+        };
+
+        /**
+         * performs final update on the sign using hexadecimal string, then returns the signature bytes of all data updates as a hexadecimal string
+         * @name signHex
+         * @memberOf KJUR.crypto.Signature
+         * @function
+         * @param {String} hex hexadecimal string to final update
+         * @return the signature bytes of a hexadecimal string
+         * @description
+         * @example
+         * var hSigValue = sig.signHex('1fdc33')
+         */
+        this.signHex = function() {
+            throw "digestHex(hex) not supported for this alg:prov=" + this.algProvName;
+        };
+
+        /**
+         * verifies the passed-in signature.
+         * @name verify
+         * @memberOf KJUR.crypto.Signature
+         * @function
+         * @param {String} str string to final update
+         * @return {Boolean} true if the signature was verified, otherwise false
+         * @description
+         * @example
+         * var isValid = sig.verify('1fbcefdca4823a7(snip)')
+         */
+        this.verify = function() {
+            throw "verify(hSigVal) not supported for this alg:prov=" + this.algProvName;
+        };
+
+        this.initParams = params;
+
+        if (params !== undefined) {
+            if (params.alg !== undefined) {
+                this.algName = params.alg;
+                if (params.prov === undefined) {
+                    this.provName = KJUR.crypto.Util.DEFAULTPROVIDER[this.algName];
+                } else {
+                    this.provName = params.prov;
+                }
+                this.algProvName = this.algName + ":" + this.provName;
+                this.setAlgAndProvider(this.algName, this.provName);
+                this._setAlgNames();
+            }
+
+            if (params.psssaltlen !== undefined) {
+                this.pssSaltLen = params.psssaltlen;
+            }
+
+            if (params.prvkeypem !== undefined) {
+                if (params.prvkeypas !== undefined) {
+                    throw "both prvkeypem and prvkeypas parameters not supported";
+                } else {
+                    try {
+                        prvKey = new RSAKey();
+                        prvKey.readPrivateKeyFromPEMString(params.prvkeypem);
+                        this.initSign(prvKey);
+                    } catch (ex) {
+                        throw "fatal error to load pem private key: " + ex;
+                    }
+                }
+            }
+        }
+    };
+
+    /**
+     * static object for cryptographic function utilities
+     * @name KJUR.crypto.OID
+     * @class static object for cryptography related OIDs
+     * @property {Array} oidhex2name key value of hexadecimal OID and its name
+     *           (ex. '2a8648ce3d030107' and 'secp256r1')
      * @since crypto 1.1.3
      * @description
-     * This method is very useful initialize method for Signature class since
-     * you just specify key then this method will automatically initialize it
-     * using {@link KEYUTIL.getKey} method.
-     * As for 'key',  following argument type are supported:
-     * <h5>signing</h5>
-     * <ul>
-     * <li>PEM formatted PKCS#8 encrypted RSA/ECDSA private key concluding "BEGIN ENCRYPTED PRIVATE KEY"</li>
-     * <li>PEM formatted PKCS#5 encrypted RSA/DSA private key concluding "BEGIN RSA/DSA PRIVATE KEY" and ",ENCRYPTED"</li>
-     * <li>PEM formatted PKCS#8 plain RSA/ECDSA private key concluding "BEGIN PRIVATE KEY"</li>
-     * <li>PEM formatted PKCS#5 plain RSA/DSA private key concluding "BEGIN RSA/DSA PRIVATE KEY" without ",ENCRYPTED"</li>
-     * <li>RSAKey object of private key</li>
-     * <li>KJUR.crypto.ECDSA object of private key</li>
-     * <li>KJUR.crypto.DSA object of private key</li>
-     * </ul>
-     * <h5>verification</h5>
-     * <ul>
-     * <li>PEM formatted PKCS#8 RSA/EC/DSA public key concluding "BEGIN PUBLIC KEY"</li>
-     * <li>PEM formatted X.509 certificate with RSA/EC/DSA public key concluding
-     *     "BEGIN CERTIFICATE", "BEGIN X509 CERTIFICATE" or "BEGIN TRUSTED CERTIFICATE".</li>
-     * <li>RSAKey object of public key</li>
-     * <li>KJUR.crypto.ECDSA object of public key</li>
-     * <li>KJUR.crypto.DSA object of public key</li>
-     * </ul>
-     * @example
-     * sig.init(sCertPEM)
      */
-    this.init = function() {
-        throw "init(key, pass) not supported for this alg:prov=" +
-        this.algProvName;
-    };
 
-    /**
-     * Initialize this object for verifying with a public key
-     * @name initVerifyByPublicKey
-     * @memberOf KJUR.crypto.Signature
-     * @function
-     * @param {Object} param RSAKey object of public key or associative array for ECDSA
-     * @since 1.0.2
-     * @deprecated from crypto 1.1.5. please use init() method instead.
-     * @description
-     * Public key information will be provided as 'param' parameter and the value will be
-     * following:
-     * <ul>
-     * <li>{@link RSAKey} object for RSA verification</li>
-     * <li>associative array for ECDSA verification
-     *     (ex. <code>{'ecpubhex': '041f..', 'eccurvename': 'secp256r1'}</code>)
-     * </li>
-     * </ul>
-     * @example
-     * sig.initVerifyByPublicKey(rsaPrvKey)
-     */
-    this.initVerifyByPublicKey = function() {
-        throw "initVerifyByPublicKey(rsaPubKeyy) not supported for this alg:prov=" +
-        this.algProvName;
-    };
 
-    /**
-     * Initialize this object for verifying with a certficate
-     * @name initVerifyByCertificatePEM
-     * @memberOf KJUR.crypto.Signature
-     * @function
-     * @param {String} certPEM PEM formatted string of certificate
-     * @since 1.0.2
-     * @deprecated from crypto 1.1.5. please use init() method instead.
-     * @description
-     * @example
-     * sig.initVerifyByCertificatePEM(certPEM)
-     */
-    this.initVerifyByCertificatePEM = function() {
-        throw "initVerifyByCertificatePEM(certPEM) not supported for this alg:prov=" +
-        this.algProvName;
-    };
-
-    /**
-     * Initialize this object for signing
-     * @name initSign
-     * @memberOf KJUR.crypto.Signature
-     * @function
-     * @param {Object} param RSAKey object of public key or associative array for ECDSA
-     * @deprecated from crypto 1.1.5. please use init() method instead.
-     * @description
-     * Private key information will be provided as 'param' parameter and the value will be
-     * following:
-     * <ul>
-     * <li>{@link RSAKey} object for RSA signing</li>
-     * <li>associative array for ECDSA signing
-     *     (ex. <code>{'ecprvhex': '1d3f..', 'eccurvename': 'secp256r1'}</code>)</li>
-     * </ul>
-     * @example
-     * sig.initSign(prvKey)
-     */
-    this.initSign = function() {
-        throw "initSign(prvKey) not supported for this alg:prov=" + this.algProvName;
-    };
-
-    /**
-     * Updates the data to be signed or verified by a string
-     * @name updateString
-     * @memberOf KJUR.crypto.Signature
-     * @function
-     * @param {String} str string to use for the update
-     * @description
-     * @example
-     * sig.updateString('aaa')
-     */
-    this.updateString = function() {
-        throw "updateString(str) not supported for this alg:prov=" + this.algProvName;
-    };
-
-    /**
-     * Updates the data to be signed or verified by a hexadecimal string
-     * @name updateHex
-     * @memberOf KJUR.crypto.Signature
-     * @function
-     * @param {String} hex hexadecimal string to use for the update
-     * @description
-     * @example
-     * sig.updateHex('1f2f3f')
-     */
-    this.updateHex = function() {
-        throw "updateHex(hex) not supported for this alg:prov=" + this.algProvName;
-    };
-
-    /**
-     * Returns the signature bytes of all data updates as a hexadecimal string
-     * @name sign
-     * @memberOf KJUR.crypto.Signature
-     * @function
-     * @return the signature bytes as a hexadecimal string
-     * @description
-     * @example
-     * var hSigValue = sig.sign()
-     */
-    this.sign = function() {
-        throw "sign() not supported for this alg:prov=" + this.algProvName;
-    };
-
-    /**
-     * performs final update on the sign using string, then returns the signature bytes of all data updates as a hexadecimal string
-     * @name signString
-     * @memberOf KJUR.crypto.Signature
-     * @function
-     * @param {String} str string to final update
-     * @return the signature bytes of a hexadecimal string
-     * @description
-     * @example
-     * var hSigValue = sig.signString('aaa')
-     */
-    this.signString = function() {
-        throw "digestString(str) not supported for this alg:prov=" + this.algProvName;
-    };
-
-    /**
-     * performs final update on the sign using hexadecimal string, then returns the signature bytes of all data updates as a hexadecimal string
-     * @name signHex
-     * @memberOf KJUR.crypto.Signature
-     * @function
-     * @param {String} hex hexadecimal string to final update
-     * @return the signature bytes of a hexadecimal string
-     * @description
-     * @example
-     * var hSigValue = sig.signHex('1fdc33')
-     */
-    this.signHex = function() {
-        throw "digestHex(hex) not supported for this alg:prov=" + this.algProvName;
-    };
-
-    /**
-     * verifies the passed-in signature.
-     * @name verify
-     * @memberOf KJUR.crypto.Signature
-     * @function
-     * @param {String} str string to final update
-     * @return {Boolean} true if the signature was verified, otherwise false
-     * @description
-     * @example
-     * var isValid = sig.verify('1fbcefdca4823a7(snip)')
-     */
-    this.verify = function() {
-        throw "verify(hSigVal) not supported for this alg:prov=" + this.algProvName;
-    };
-
-    this.initParams = params;
-
-    if (params !== undefined) {
-        if (params.alg !== undefined) {
-            this.algName = params.alg;
-            if (params.prov === undefined) {
-                this.provName = KJUR.crypto.Util.DEFAULTPROVIDER[this.algName];
-            } else {
-                this.provName = params.prov;
-            }
-            this.algProvName = this.algName + ":" + this.provName;
-            this.setAlgAndProvider(this.algName, this.provName);
-            this._setAlgNames();
+    KJUR.crypto.OID = {
+        oidhex2name: {
+            '2a864886f70d010101': 'rsaEncryption',
+            '2a8648ce3d0201': 'ecPublicKey',
+            '2a8648ce380401': 'dsa',
+            '2a8648ce3d030107': 'secp256r1',
+            '2b8104001f': 'secp192k1',
+            '2b81040021': 'secp224r1',
+            '2b8104000a': 'secp256k1',
+            '2b81040023': 'secp521r1',
+            '2b81040022': 'secp384r1',
+            '2a8648ce380403': 'SHA1withDSA', // 1.2.840.10040.4.3
+            '608648016503040301': 'SHA224withDSA', // 2.16.840.1.101.3.4.3.1
+            '608648016503040302': 'SHA256withDSA', // 2.16.840.1.101.3.4.3.2
         }
-
-        if (params.psssaltlen !== undefined) {
-            this.pssSaltLen = params.psssaltlen;
-        }
-
-        if (params.prvkeypem !== undefined) {
-            if (params.prvkeypas !== undefined) {
-                throw "both prvkeypem and prvkeypas parameters not supported";
-            } else {
-                try {
-                    prvKey = new RSAKey();
-                    prvKey.readPrivateKeyFromPEMString(params.prvkeypem);
-                    this.initSign(prvKey);
-                } catch (ex) {
-                    throw "fatal error to load pem private key: " + ex;
-                }
-            }
-        }
-    }
-};
-
-/**
- * static object for cryptographic function utilities
- * @name KJUR.crypto.OID
- * @class static object for cryptography related OIDs
- * @property {Array} oidhex2name key value of hexadecimal OID and its name
- *           (ex. '2a8648ce3d030107' and 'secp256r1')
- * @since crypto 1.1.3
- * @description
- */
-
-
-KJUR.crypto.OID = {
-    oidhex2name: {
-        '2a864886f70d010101': 'rsaEncryption',
-        '2a8648ce3d0201': 'ecPublicKey',
-        '2a8648ce380401': 'dsa',
-        '2a8648ce3d030107': 'secp256r1',
-        '2b8104001f': 'secp192k1',
-        '2b81040021': 'secp224r1',
-        '2b8104000a': 'secp256k1',
-        '2b81040023': 'secp521r1',
-        '2b81040022': 'secp384r1',
-        '2a8648ce380403': 'SHA1withDSA', // 1.2.840.10040.4.3
-        '608648016503040301': 'SHA224withDSA', // 2.16.840.1.101.3.4.3.1
-        '608648016503040302': 'SHA256withDSA', // 2.16.840.1.101.3.4.3.2
-    }
-};
+    };
+}.call(this));

--- a/keyutil-1.0.js
+++ b/keyutil-1.0.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*! keyutil-1.0.7.js (c) 2013-2014 Kenji Urushima | kjur.github.com/jsrsasign/license
  */
 /*
@@ -8,7 +10,7 @@
  * This software is licensed under the terms of the MIT License.
  * http://kjur.github.com/jsrsasign/license
  *
- * The above copyright and license notice shall be 
+ * The above copyright and license notice shall be
  * included in all copies or substantial portions of the Software.
  */
 /**
@@ -23,7 +25,7 @@
 /**
  * @name KEYUTIL
  * @class class for RSA/ECC/DSA key utility
- * @description 
+ * @description
  * <br/>
  * {@link KEYUTIL} class is an update of former {@link PKCS5PKEY} class.
  * So for now, {@link PKCS5PKEY} is deprecated class.
@@ -60,7 +62,7 @@
  * </ul>
  * NOTE: {@link KJUR.crypto.DSA} is not yet supported.
  * </dl>
- * 
+ *
  * @example
  * // 1. loading private key
  * var key = KEYUTIL.getKey(pemPKCS1PrivateKey);
@@ -162,7 +164,7 @@ var KEYUTIL = function() {
     };
 
     var getFuncByName = function(algName) {
-        return ALGLIST[algName]['proc'];
+        return ALGLIST[algName].proc;
     };
 
     var _generateIvSaltHex = function(numBytes) {
@@ -182,16 +184,16 @@ var KEYUTIL = function() {
         }
         var i1 = -1;
         var lenNEWLINE = 0;
-        if (sPKCS5PEM.indexOf("\r\n\r\n") != -1) {
+        if (sPKCS5PEM.indexOf("\r\n\r\n") !== -1) {
             i1 = sPKCS5PEM.indexOf("\r\n\r\n");
             lenNEWLINE = 2;
         }
-        if (sPKCS5PEM.indexOf("\n\n") != -1) {
+        if (sPKCS5PEM.indexOf("\n\n") !== -1) {
             i1 = sPKCS5PEM.indexOf("\n\n");
             lenNEWLINE = 1;
         }
         var i2 = sPKCS5PEM.indexOf("-----END");
-        if (i1 != -1 && i2 != -1) {
+        if (i1 !== -1 && i2 !== -1) {
             var s = sPKCS5PEM.substring(i1 + lenNEWLINE * 2, i2 - lenNEWLINE);
             s = s.replace(/\s+/g, '');
             info.data = s;
@@ -203,19 +205,19 @@ var KEYUTIL = function() {
         //alert("ivsaltHex(2) = " + ivsaltHex);
         var saltHex = ivsaltHex.substring(0, 16);
         //alert("salt = " + saltHex);
-        
+
         var salt = CryptoJS.enc.Hex.parse(saltHex);
         var data = CryptoJS.enc.Utf8.parse(passcode);
         //alert("salt = " + salt);
         //alert("data = " + data);
 
-        var nRequiredBytes = ALGLIST[algName]['keylen'] + ALGLIST[algName]['ivlen'];
+        var nRequiredBytes = ALGLIST[algName].keylen + ALGLIST[algName].ivlen;
         var hHexValueJoined = '';
         var hLastValue = null;
         //alert("nRequiredBytes = " + nRequiredBytes);
         for (;;) {
             var h = CryptoJS.algo.MD5.create();
-            if (hLastValue != null) {
+            if (hLastValue !== null) {
                 h.update(hLastValue);
             }
             h.update(data);
@@ -228,8 +230,8 @@ var KEYUTIL = function() {
             }
         }
         var result = {};
-        result.keyhex = hHexValueJoined.substr(0, ALGLIST[algName]['keylen'] * 2);
-        result.ivhex = hHexValueJoined.substr(ALGLIST[algName]['keylen'] * 2, ALGLIST[algName]['ivlen'] * 2);
+        result.keyhex = hHexValueJoined.substr(0, ALGLIST[algName].keylen * 2);
+        result.ivhex = hHexValueJoined.substr(ALGLIST[algName].keylen * 2, ALGLIST[algName].ivlen * 2);
         return result;
     };
 
@@ -243,11 +245,11 @@ var KEYUTIL = function() {
     var _decryptKeyB64 = function(privateKeyB64, sharedKeyAlgName, sharedKeyHex, ivsaltHex) {
         var privateKeyWA = CryptoJS.enc.Base64.parse(privateKeyB64);
         var privateKeyHex = CryptoJS.enc.Hex.stringify(privateKeyWA);
-        var f = ALGLIST[sharedKeyAlgName]['proc'];
+        var f = ALGLIST[sharedKeyAlgName].proc;
         var decryptedKeyHex = f(privateKeyHex, sharedKeyHex, ivsaltHex);
         return decryptedKeyHex;
     };
-    
+
     /*
      * @param {String} privateKeyHex hexadecimal string of private key
      * @param {String} sharedKeyAlgName algorithm name of shared key encryption
@@ -256,7 +258,7 @@ var KEYUTIL = function() {
      * @param {String} base64 string of encrypted private key
      */
     var _encryptKeyHex = function(privateKeyHex, sharedKeyAlgName, sharedKeyHex, ivsaltHex) {
-        var f = ALGLIST[sharedKeyAlgName]['eproc'];
+        var f = ALGLIST[sharedKeyAlgName].eproc;
         var encryptedKeyB64 = f(privateKeyHex, sharedKeyHex, ivsaltHex);
         return encryptedKeyB64;
     };
@@ -287,10 +289,10 @@ var KEYUTIL = function() {
          */
         getHexFromPEM: function(sPEM, sHead) {
             var s = sPEM;
-            if (s.indexOf("-----BEGIN ") == -1) {
+            if (s.indexOf("-----BEGIN ") === -1) {
                 throw "can't find PEM header: " + sHead;
             }
-            if (typeof sHead == "string" && sHead != "") {
+            if (typeof sHead === "string" && sHead !== "") {
                 s = s.replace("-----BEGIN " + sHead + "-----", "");
                 s = s.replace("-----END " + sHead + "-----", "");
             } else {
@@ -426,26 +428,27 @@ var KEYUTIL = function() {
          * </ul>
          * NOTE1: DES-CBC, DES-EDE3-CBC, AES-{128,192.256}-CBC algorithm are supported.
          * @example
-         * var pem = 
+         * var pem =
          *   KEYUTIL.getEncryptedPKCS5PEMFromPrvKeyHex(plainKeyHex, "password");
-         * var pem2 = 
+         * var pem2 =
          *   KEYUTIL.getEncryptedPKCS5PEMFromPrvKeyHex(plainKeyHex, "password", "AES-128-CBC");
-         * var pem3 = 
+         * var pem3 =
          *   KEYUTIL.getEncryptedPKCS5PEMFromPrvKeyHex(plainKeyHex, "password", "AES-128-CBC", "1f3d02...");
          */
         getEncryptedPKCS5PEMFromPrvKeyHex: function(pemHeadAlg, hPrvKey, passcode, sharedKeyAlgName, ivsaltHex) {
             var sPEM = "";
 
             // 1. set sharedKeyAlgName if undefined (default AES-256-CBC)
-            if (typeof sharedKeyAlgName == "undefined" || sharedKeyAlgName == null) {
+            if (typeof sharedKeyAlgName === "undefined" || sharedKeyAlgName === null) {
                 sharedKeyAlgName = "AES-256-CBC";
             }
-            if (typeof ALGLIST[sharedKeyAlgName] == "undefined")
+            if (typeof ALGLIST[sharedKeyAlgName] === "undefined") {
                 throw "KEYUTIL unsupported algorithm: " + sharedKeyAlgName;
+            }
 
             // 2. set ivsaltHex if undefined
-            if (typeof ivsaltHex == "undefined" || ivsaltHex == null) {
-                var ivlen = ALGLIST[sharedKeyAlgName]['ivlen'];
+            if (typeof ivsaltHex === "undefined" || ivsaltHex === null) {
+                var ivlen = ALGLIST[sharedKeyAlgName].ivlen;
                 var randIV = _generateIvSaltHex(ivlen);
                 ivsaltHex = randIV.toUpperCase();
             }
@@ -528,16 +531,16 @@ var KEYUTIL = function() {
          * var pem3 = KEYUTIL.newEncryptedPKCS5PEM("password", 512, '3'); // RSA 512bit/    3/AES-256-CBC
          */
         newEncryptedPKCS5PEM: function(passcode, keyLen, hPublicExponent, alg) {
-            if (typeof keyLen == "undefined" || keyLen == null) {
+            if (typeof keyLen === "undefined" || keyLen === null) {
                 keyLen = 1024;
             }
-            if (typeof hPublicExponent == "undefined" || hPublicExponent == null) {
+            if (typeof hPublicExponent === "undefined" || hPublicExponent === null) {
                 hPublicExponent = '10001';
             }
             var pKey = new RSAKey();
             pKey.generate(keyLen, hPublicExponent);
             var pem = null;
-            if (typeof alg == "undefined" || alg == null) {
+            if (typeof alg === "undefined" || alg === null) {
                 pem = this.getEncryptedPKCS5PEMFromRSAKey(pKey, passcode);
             } else {
                 pem = this.getEncryptedPKCS5PEMFromRSAKey(pKey, passcode, alg);
@@ -558,8 +561,9 @@ var KEYUTIL = function() {
          * @deprecated From jsrsasign 4.2.1 please use {@link KEYUTIL.getKey#}.
          */
         getRSAKeyFromPlainPKCS8PEM: function(pkcs8PEM) {
-            if (pkcs8PEM.match(/ENCRYPTED/))
+            if (pkcs8PEM.match(/ENCRYPTED/)) {
                 throw "pem shall be not ENCRYPTED";
+            }
             var prvKeyHex = this.getHexFromPEM(pkcs8PEM, "PRIVATE KEY");
             var rsaKey = this.getRSAKeyFromPlainPKCS8Hex(prvKeyHex);
             return rsaKey;
@@ -577,11 +581,13 @@ var KEYUTIL = function() {
          */
         getRSAKeyFromPlainPKCS8Hex: function(prvKeyHex) {
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(prvKeyHex, 0);
-            if (a1.length != 3)
+            if (a1.length !== 3) {
                 throw "outer DERSequence shall have 3 elements: " + a1.length;
+            }
             var algIdTLV =ASN1HEX.getHexOfTLV_AtObj(prvKeyHex, a1[1]);
-            if (algIdTLV != "300d06092a864886f70d0101010500") // AlgId rsaEncryption
+            if (algIdTLV !== "300d06092a864886f70d0101010500") {
                 throw "PKCS8 AlgorithmIdentifier is not rsaEnc: " + algIdTLV;
+            }
             var algIdTLV = ASN1HEX.getHexOfTLV_AtObj(prvKeyHex, a1[1]);
             var octetStr = ASN1HEX.getHexOfTLV_AtObj(prvKeyHex, a1[2]);
             var p5KeyHex = ASN1HEX.getHexOfV_AtObj(octetStr, 0);
@@ -620,50 +626,59 @@ var KEYUTIL = function() {
          */
         parseHexOfEncryptedPKCS8: function(sHEX) {
             var info = {};
-            
+
             var a0 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, 0);
-            if (a0.length != 2)
+            if (a0.length !== 2) {
                 throw "malformed format: SEQUENCE(0).items != 2: " + a0.length;
+            }
 
             // 1. ciphertext
             info.ciphertext = ASN1HEX.getHexOfV_AtObj(sHEX, a0[1]);
 
             // 2. pkcs5PBES2
-            var a0_0 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0[0]); 
-            if (a0_0.length != 2)
+            var a0_0 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0[0]);
+            if (a0_0.length !== 2) {
                 throw "malformed format: SEQUENCE(0.0).items != 2: " + a0_0.length;
+            }
 
             // 2.1 check if pkcs5PBES2(1 2 840 113549 1 5 13)
-            if (ASN1HEX.getHexOfV_AtObj(sHEX, a0_0[0]) != "2a864886f70d01050d")
+            if (ASN1HEX.getHexOfV_AtObj(sHEX, a0_0[0]) !== "2a864886f70d01050d") {
                 throw "this only supports pkcs5PBES2";
+            }
 
             // 2.2 pkcs5PBES2 param
-            var a0_0_1 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0_0[1]); 
-            if (a0_0.length != 2)
+            var a0_0_1 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0_0[1]);
+            if (a0_0.length !== 2) {
                 throw "malformed format: SEQUENCE(0.0.1).items != 2: " + a0_0_1.length;
+            }
 
             // 2.2.1 encryptionScheme
-            var a0_0_1_1 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0_0_1[1]); 
-            if (a0_0_1_1.length != 2)
+            var a0_0_1_1 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0_0_1[1]);
+            if (a0_0_1_1.length !== 2) {
                 throw "malformed format: SEQUENCE(0.0.1.1).items != 2: " + a0_0_1_1.length;
-            if (ASN1HEX.getHexOfV_AtObj(sHEX, a0_0_1_1[0]) != "2a864886f70d0307")
+            }
+            if (ASN1HEX.getHexOfV_AtObj(sHEX, a0_0_1_1[0]) !== "2a864886f70d0307") {
                 throw "this only supports TripleDES";
+            }
             info.encryptionSchemeAlg = "TripleDES";
 
             // 2.2.1.1 IV of encryptionScheme
             info.encryptionSchemeIV = ASN1HEX.getHexOfV_AtObj(sHEX, a0_0_1_1[1]);
 
             // 2.2.2 keyDerivationFunc
-            var a0_0_1_0 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0_0_1[0]); 
-            if (a0_0_1_0.length != 2)
+            var a0_0_1_0 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0_0_1[0]);
+            if (a0_0_1_0.length !== 2) {
                 throw "malformed format: SEQUENCE(0.0.1.0).items != 2: " + a0_0_1_0.length;
-            if (ASN1HEX.getHexOfV_AtObj(sHEX, a0_0_1_0[0]) != "2a864886f70d01050c")
+            }
+            if (ASN1HEX.getHexOfV_AtObj(sHEX, a0_0_1_0[0]) !== "2a864886f70d01050c") {
                 throw "this only supports pkcs5PBKDF2";
+            }
 
             // 2.2.2.1 pkcs5PBKDF2 param
-            var a0_0_1_0_1 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0_0_1_0[1]); 
-            if (a0_0_1_0_1.length < 2)
+            var a0_0_1_0_1 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0_0_1_0[1]);
+            if (a0_0_1_0_1.length < 2) {
                 throw "malformed format: SEQUENCE(0.0.1.0.1).items < 2: " + a0_0_1_0_1.length;
+            }
 
             // 2.2.2.1.1 PBKDF2 salt
             info.pbkdf2Salt = ASN1HEX.getHexOfV_AtObj(sHEX, a0_0_1_0_1[0]);
@@ -707,8 +722,8 @@ var KEYUTIL = function() {
         getPBKDF2KeyHexFromParam: function(info, passcode) {
             var pbkdf2SaltWS = CryptoJS.enc.Hex.parse(info.pbkdf2Salt);
             var pbkdf2Iter = info.pbkdf2Iter;
-            var pbkdf2KeyWS = CryptoJS.PBKDF2(passcode, 
-                                              pbkdf2SaltWS, 
+            var pbkdf2KeyWS = CryptoJS.PBKDF2(passcode,
+                                              pbkdf2SaltWS,
                                               { keySize: 192/32, iterations: pbkdf2Iter });
             var pbkdf2KeyHex = CryptoJS.enc.Hex.stringify(pbkdf2KeyWS);
             return pbkdf2KeyHex;
@@ -815,35 +830,41 @@ var KEYUTIL = function() {
             result.algparam = null;
 
             // 1. sequence
-            if (pkcs8PrvHex.substr(0, 2) != "30")
-                throw "malformed plain PKCS8 private key(code:001)"; // not sequence
+            if (pkcs8PrvHex.substr(0, 2) !== "30") {
+                throw "malformed plain PKCS8 private key(code:001)";
+            } // not sequence
 
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PrvHex, 0);
-            if (a1.length != 3)
+            if (a1.length !== 3) {
                 throw "malformed plain PKCS8 private key(code:002)";
+            }
 
             // 2. AlgID
-            if (pkcs8PrvHex.substr(a1[1], 2) != "30")
-                throw "malformed PKCS8 private key(code:003)"; // AlgId not sequence
+            if (pkcs8PrvHex.substr(a1[1], 2) !== "30") {
+                throw "malformed PKCS8 private key(code:003)";
+            } // AlgId not sequence
 
             var a2 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PrvHex, a1[1]);
-            if (a2.length != 2)
-                throw "malformed PKCS8 private key(code:004)"; // AlgId not have two elements
+            if (a2.length !== 2) {
+                throw "malformed PKCS8 private key(code:004)";
+            } // AlgId not have two elements
 
             // 2.1. AlgID OID
-            if (pkcs8PrvHex.substr(a2[0], 2) != "06")
-                throw "malformed PKCS8 private key(code:005)"; // AlgId.oid is not OID
+            if (pkcs8PrvHex.substr(a2[0], 2) !== "06") {
+                throw "malformed PKCS8 private key(code:005)";
+            } // AlgId.oid is not OID
 
             result.algoid = ASN1HEX.getHexOfV_AtObj(pkcs8PrvHex, a2[0]);
 
             // 2.2. AlgID param
-            if (pkcs8PrvHex.substr(a2[1], 2) == "06") {
+            if (pkcs8PrvHex.substr(a2[1], 2) === "06") {
                 result.algparam = ASN1HEX.getHexOfV_AtObj(pkcs8PrvHex, a2[1]);
             }
 
             // 3. Key index
-            if (pkcs8PrvHex.substr(a1[2], 2) != "04")
-                throw "malformed PKCS8 private key(code:006)"; // not octet string
+            if (pkcs8PrvHex.substr(a1[2], 2) !== "04") {
+                throw "malformed PKCS8 private key(code:006)";
+            } // not octet string
 
             result.keyidx = ASN1HEX.getStartPosOfV_AtObj(pkcs8PrvHex, a1[2]);
 
@@ -876,24 +897,25 @@ var KEYUTIL = function() {
          */
         getKeyFromPlainPrivatePKCS8Hex: function(prvKeyHex) {
             var p8 = this.parsePlainPrivatePKCS8Hex(prvKeyHex);
-            
-            if (p8.algoid == "2a864886f70d010101") { // RSA
+
+            if (p8.algoid === "2a864886f70d010101") { // RSA
                 this.parsePrivateRawRSAKeyHexAtObj(prvKeyHex, p8);
                 var k = p8.key;
                 var key = new RSAKey();
                 key.setPrivateEx(k.n, k.e, k.d, k.p, k.q, k.dp, k.dq, k.co);
                 return key;
-            } else if (p8.algoid == "2a8648ce3d0201") { // ECC
+            } else if (p8.algoid === "2a8648ce3d0201") { // ECC
                 this.parsePrivateRawECKeyHexAtObj(prvKeyHex, p8);
-                if (KJUR.crypto.OID.oidhex2name[p8.algparam] === undefined)
+                if (KJUR.crypto.OID.oidhex2name[p8.algparam] === undefined) {
                     throw "KJUR.crypto.OID.oidhex2name undefined: " + p8.algparam;
+                }
                 var curveName = KJUR.crypto.OID.oidhex2name[p8.algparam];
                 var key = new KJUR.crypto.ECDSA({'curve': curveName});
                 key.setPublicKeyHex(p8.pubkey);
                 key.setPrivateKeyHex(p8.key);
                 key.isPublic = false;
                 return key;
-            } else if (p8.algoid == "2a8648ce380401") { // DSA
+            } else if (p8.algoid === "2a8648ce380401") { // DSA
                 var hP = ASN1HEX.getVbyList(prvKeyHex, 0, [1,1,0], "02");
                 var hQ = ASN1HEX.getVbyList(prvKeyHex, 0, [1,1,1], "02");
                 var hG = ASN1HEX.getVbyList(prvKeyHex, 0, [1,1,2], "02");
@@ -955,19 +977,20 @@ var KEYUTIL = function() {
          */
         getKeyFromPublicPKCS8Hex: function(pkcs8PubHex) {
             var p8 = this.parsePublicPKCS8Hex(pkcs8PubHex);
-            
-            if (p8.algoid == "2a864886f70d010101") { // RSA
+
+            if (p8.algoid === "2a864886f70d010101") { // RSA
                 var aRSA = this.parsePublicRawRSAKeyHex(p8.key);
                 var key = new RSAKey();
                 key.setPublic(aRSA.n, aRSA.e);
                 return key;
-            } else if (p8.algoid == "2a8648ce3d0201") { // ECC
-                if (KJUR.crypto.OID.oidhex2name[p8.algparam] === undefined)
+            } else if (p8.algoid === "2a8648ce3d0201") { // ECC
+                if (KJUR.crypto.OID.oidhex2name[p8.algparam] === undefined) {
                     throw "KJUR.crypto.OID.oidhex2name undefined: " + p8.algparam;
+                }
                 var curveName = KJUR.crypto.OID.oidhex2name[p8.algparam];
                 var key = new KJUR.crypto.ECDSA({'curve': curveName, 'pub': p8.key});
                 return key;
-            } else if (p8.algoid == "2a8648ce380401") { // DSA 1.2.840.10040.4.1
+            } else if (p8.algoid === "2a8648ce380401") { // DSA 1.2.840.10040.4.1
                 var param = p8.algparam;
                 var y = ASN1HEX.getHexOfV_AtObj(p8.key, 0);
                 var key = new KJUR.crypto.DSA();
@@ -998,24 +1021,28 @@ var KEYUTIL = function() {
          */
         parsePublicRawRSAKeyHex: function(pubRawRSAHex) {
             var result = {};
-            
+
             // 1. Sequence
-            if (pubRawRSAHex.substr(0, 2) != "30")
-                throw "malformed RSA key(code:001)"; // not sequence
-            
+            if (pubRawRSAHex.substr(0, 2) !== "30") {
+                throw "malformed RSA key(code:001)";
+            } // not sequence
+
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(pubRawRSAHex, 0);
-            if (a1.length != 2)
-                throw "malformed RSA key(code:002)"; // not 2 items in seq
+            if (a1.length !== 2) {
+                throw "malformed RSA key(code:002)";
+            } // not 2 items in seq
 
             // 2. public key "N"
-            if (pubRawRSAHex.substr(a1[0], 2) != "02")
-                throw "malformed RSA key(code:003)"; // 1st item is not integer
+            if (pubRawRSAHex.substr(a1[0], 2) !== "02") {
+                throw "malformed RSA key(code:003)";
+            } // 1st item is not integer
 
             result.n = ASN1HEX.getHexOfV_AtObj(pubRawRSAHex, a1[0]);
 
             // 3. public key "E"
-            if (pubRawRSAHex.substr(a1[1], 2) != "02")
-                throw "malformed RSA key(code:004)"; // 2nd item is not integer
+            if (pubRawRSAHex.substr(a1[1], 2) !== "02") {
+                throw "malformed RSA key(code:004)";
+            } // 2nd item is not integer
 
             result.e = ASN1HEX.getHexOfV_AtObj(pubRawRSAHex, a1[1]);
 
@@ -1045,14 +1072,16 @@ var KEYUTIL = function() {
          */
         parsePrivateRawRSAKeyHexAtObj: function(pkcs8PrvHex, info) {
             var keyIdx = info.keyidx;
-            
+
             // 1. sequence
-            if (pkcs8PrvHex.substr(keyIdx, 2) != "30")
-                throw "malformed RSA private key(code:001)"; // not sequence
+            if (pkcs8PrvHex.substr(keyIdx, 2) !== "30") {
+                throw "malformed RSA private key(code:001)";
+            } // not sequence
 
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PrvHex, keyIdx);
-            if (a1.length != 9)
-                throw "malformed RSA private key(code:002)"; // not sequence
+            if (a1.length !== 9) {
+                throw "malformed RSA private key(code:002)";
+            } // not sequence
 
             // 2. RSA key
             info.key = {};
@@ -1082,7 +1111,7 @@ var KEYUTIL = function() {
          */
         parsePrivateRawECKeyHexAtObj: function(pkcs8PrvHex, info) {
             var keyIdx = info.keyidx;
-            
+
             var key = ASN1HEX.getVbyList(pkcs8PrvHex, keyIdx, [1], "04");
             var pubkey = ASN1HEX.getVbyList(pkcs8PrvHex, keyIdx, [2,0], "03").substr(2);
 
@@ -1111,28 +1140,32 @@ var KEYUTIL = function() {
 
             // 1. AlgID and Key bit string
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PubHex, 0);
-            if (a1.length != 2)
+            if (a1.length !== 2) {
                 throw "outer DERSequence shall have 2 elements: " + a1.length;
+            }
 
             // 2. AlgID
             var idxAlgIdTLV = a1[0];
-            if (pkcs8PubHex.substr(idxAlgIdTLV, 2) != "30")
-                throw "malformed PKCS8 public key(code:001)"; // AlgId not sequence
+            if (pkcs8PubHex.substr(idxAlgIdTLV, 2) !== "30") {
+                throw "malformed PKCS8 public key(code:001)";
+            } // AlgId not sequence
 
             var a2 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PubHex, idxAlgIdTLV);
-            if (a2.length != 2)
-                throw "malformed PKCS8 public key(code:002)"; // AlgId not have two elements
+            if (a2.length !== 2) {
+                throw "malformed PKCS8 public key(code:002)";
+            } // AlgId not have two elements
 
             // 2.1. AlgID OID
-            if (pkcs8PubHex.substr(a2[0], 2) != "06")
-                throw "malformed PKCS8 public key(code:003)"; // AlgId.oid is not OID
+            if (pkcs8PubHex.substr(a2[0], 2) !== "06") {
+                throw "malformed PKCS8 public key(code:003)";
+            } // AlgId.oid is not OID
 
             result.algoid = ASN1HEX.getHexOfV_AtObj(pkcs8PubHex, a2[0]);
 
             // 2.2. AlgID param
-            if (pkcs8PubHex.substr(a2[1], 2) == "06") { // OID for EC
+            if (pkcs8PubHex.substr(a2[1], 2) === "06") { // OID for EC
                 result.algparam = ASN1HEX.getHexOfV_AtObj(pkcs8PubHex, a2[1]);
-            } else if (pkcs8PubHex.substr(a2[1], 2) == "30") { // SEQ for DSA
+            } else if (pkcs8PubHex.substr(a2[1], 2) === "30") { // SEQ for DSA
                 result.algparam = {};
                 result.algparam.p = ASN1HEX.getVbyList(pkcs8PubHex, a2[1], [0], "02");
                 result.algparam.q = ASN1HEX.getVbyList(pkcs8PubHex, a2[1], [1], "02");
@@ -1140,11 +1173,12 @@ var KEYUTIL = function() {
             }
 
             // 3. Key
-            if (pkcs8PubHex.substr(a1[1], 2) != "03")
-                throw "malformed PKCS8 public key(code:004)"; // Key is not bit string
+            if (pkcs8PubHex.substr(a1[1], 2) !== "03") {
+                throw "malformed PKCS8 public key(code:004)";
+            } // Key is not bit string
 
             result.key = ASN1HEX.getHexOfV_AtObj(pkcs8PubHex, a1[1]).substr(2);
-            
+
             // 4. return result assoc array
             return result;
         },
@@ -1161,36 +1195,43 @@ var KEYUTIL = function() {
          */
         getRSAKeyFromPublicPKCS8Hex: function(pkcs8PubHex) {
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PubHex, 0);
-            if (a1.length != 2)
+            if (a1.length !== 2) {
                 throw "outer DERSequence shall have 2 elements: " + a1.length;
+            }
 
             var algIdTLV =ASN1HEX.getHexOfTLV_AtObj(pkcs8PubHex, a1[0]);
-            if (algIdTLV != "300d06092a864886f70d0101010500") // AlgId rsaEncryption
+            if (algIdTLV !== "300d06092a864886f70d0101010500") {
                 throw "PKCS8 AlgorithmId is not rsaEncryption";
-            
-            if (pkcs8PubHex.substr(a1[1], 2) != "03")
+            }
+
+            if (pkcs8PubHex.substr(a1[1], 2) !== "03") {
                 throw "PKCS8 Public Key is not BITSTRING encapslated.";
+            }
 
             var idxPub = ASN1HEX.getStartPosOfV_AtObj(pkcs8PubHex, a1[1]) + 2; // 2 for unused bit
-            
-            if (pkcs8PubHex.substr(idxPub, 2) != "30")
+
+            if (pkcs8PubHex.substr(idxPub, 2) !== "30") {
                 throw "PKCS8 Public Key is not SEQUENCE.";
+            }
 
             var a2 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PubHex, idxPub);
-            if (a2.length != 2)
+            if (a2.length !== 2) {
                 throw "inner DERSequence shall have 2 elements: " + a2.length;
+            }
 
-            if (pkcs8PubHex.substr(a2[0], 2) != "02") 
+            if (pkcs8PubHex.substr(a2[0], 2) !== "02") {
                 throw "N is not ASN.1 INTEGER";
-            if (pkcs8PubHex.substr(a2[1], 2) != "02") 
+            }
+            if (pkcs8PubHex.substr(a2[1], 2) !== "02") {
                 throw "E is not ASN.1 INTEGER";
-            
+            }
+
             var hN = ASN1HEX.getHexOfV_AtObj(pkcs8PubHex, a2[0]);
             var hE = ASN1HEX.getHexOfV_AtObj(pkcs8PubHex, a2[1]);
 
             var pubKey = new RSAKey();
             pubKey.setPublic(hN, hE);
-            
+
             return pubKey;
         },
 
@@ -1247,12 +1288,15 @@ var KEYUTIL = function() {
  */
 KEYUTIL.getKey = function(param, passcode, hextype) {
     // 1. by key object
-    if (typeof RSAKey != 'undefined' && param instanceof RSAKey)
+    if (typeof RSAKey !== 'undefined' && param instanceof RSAKey) {
         return param;
-    if (typeof KJUR.crypto.ECDSA != 'undefined' && param instanceof KJUR.crypto.ECDSA)
+    }
+    if (typeof KJUR.crypto.ECDSA !== 'undefined' && param instanceof KJUR.crypto.ECDSA) {
         return param;
-    if (typeof KJUR.crypto.DSA != 'undefined' && param instanceof KJUR.crypto.DSA)
+    }
+    if (typeof KJUR.crypto.DSA !== 'undefined' && param instanceof KJUR.crypto.DSA) {
         return param;
+    }
 
     // 2. by key spec
     // 2.1. ECC private key
@@ -1269,7 +1313,7 @@ KEYUTIL.getKey = function(param, passcode, hextype) {
         return key;
     }
     // 2.3. DSA private key
-    if (param.p !== undefined && param.q !== undefined && param.g !== undefined && 
+    if (param.p !== undefined && param.q !== undefined && param.g !== undefined &&
         param.y !== undefined && param.x !== undefined) {
         var key = new KJUR.crypto.DSA();
         key.setPrivate(param.p, param.q, param.g, param.y, param.x);
@@ -1287,7 +1331,7 @@ KEYUTIL.getKey = function(param, passcode, hextype) {
         return key;
     }
     // 2.6. DSA public key
-    if (param.p !== undefined && param.q !== undefined && param.g !== undefined && 
+    if (param.p !== undefined && param.q !== undefined && param.g !== undefined &&
         param.y !== undefined && param.x === undefined) {
         var key = new KJUR.crypto.DSA();
         key.setPublic(param.p, param.q, param.g, param.y);
@@ -1295,9 +1339,9 @@ KEYUTIL.getKey = function(param, passcode, hextype) {
     }
 
     // 3. by cert
-    if (param.indexOf("-END CERTIFICATE-", 0) != -1 ||
-        param.indexOf("-END X509 CERTIFICATE-", 0) != -1 ||
-        param.indexOf("-END TRUSTED CERTIFICATE-", 0) != -1) {
+    if (param.indexOf("-END CERTIFICATE-", 0) !== -1 ||
+        param.indexOf("-END X509 CERTIFICATE-", 0) !== -1 ||
+        param.indexOf("-END TRUSTED CERTIFICATE-", 0) !== -1) {
         return X509.getPublicKeyFromCertPEM(param);
     }
 
@@ -1307,10 +1351,10 @@ KEYUTIL.getKey = function(param, passcode, hextype) {
     }
 
     // 5. public key by PKCS#8 PEM string
-    if (param.indexOf("-END PUBLIC KEY-") != -1) {
+    if (param.indexOf("-END PUBLIC KEY-") !== -1) {
         return KEYUTIL.getKeyFromPublicPKCS8PEM(param);
     }
-    
+
     // 6. private key by PKCS#5 plain hexadecimal RSA string
     if (hextype === "pkcs5prv") {
         var key = new RSAKey();
@@ -1326,16 +1370,16 @@ KEYUTIL.getKey = function(param, passcode, hextype) {
     }
 
     // 8. private key by plain PKCS#5 PEM RSA string
-    if (param.indexOf("-END RSA PRIVATE KEY-") != -1 &&
-        param.indexOf("4,ENCRYPTED") == -1) {
+    if (param.indexOf("-END RSA PRIVATE KEY-") !== -1 &&
+        param.indexOf("4,ENCRYPTED") === -1) {
         var key = new RSAKey();
         key.readPrivateKeyFromPEMString(param);
         return key;
     }
 
     // 8.2. private key by plain PKCS#5 PEM DSA string
-    if (param.indexOf("-END DSA PRIVATE KEY-") != -1 &&
-        param.indexOf("4,ENCRYPTED") == -1) {
+    if (param.indexOf("-END DSA PRIVATE KEY-") !== -1 &&
+        param.indexOf("4,ENCRYPTED") === -1) {
 
         var hKey = this.getHexFromPEM(param, "DSA PRIVATE KEY");
         var p = ASN1HEX.getVbyList(hKey, 0, [1], "02");
@@ -1353,19 +1397,19 @@ KEYUTIL.getKey = function(param, passcode, hextype) {
     }
 
     // 9. private key by plain PKCS#8 PEM ECC/RSA string
-    if (param.indexOf("-END PRIVATE KEY-") != -1) {
+    if (param.indexOf("-END PRIVATE KEY-") !== -1) {
         return KEYUTIL.getKeyFromPlainPrivatePKCS8PEM(param);
     }
 
     // 10. private key by encrypted PKCS#5 PEM RSA string
-    if (param.indexOf("-END RSA PRIVATE KEY-") != -1 &&
-        param.indexOf("4,ENCRYPTED") != -1) {
+    if (param.indexOf("-END RSA PRIVATE KEY-") !== -1 &&
+        param.indexOf("4,ENCRYPTED") !== -1) {
         return KEYUTIL.getRSAKeyFromEncryptedPKCS5PEM(param, passcode);
     }
 
     // 10.2. private key by encrypted PKCS#5 PEM ECDSA string
-    if (param.indexOf("-END EC PRIVATE KEY-") != -1 &&
-        param.indexOf("4,ENCRYPTED") != -1) {
+    if (param.indexOf("-END EC PRIVATE KEY-") !== -1 &&
+        param.indexOf("4,ENCRYPTED") !== -1) {
         var hKey = KEYUTIL.getDecryptedKeyHex(param, passcode);
 
         var key = ASN1HEX.getVbyList(hKey, 0, [1], "04");
@@ -1387,8 +1431,8 @@ KEYUTIL.getKey = function(param, passcode, hextype) {
     }
 
     // 10.3. private key by encrypted PKCS#5 PEM DSA string
-    if (param.indexOf("-END DSA PRIVATE KEY-") != -1 &&
-        param.indexOf("4,ENCRYPTED") != -1) {
+    if (param.indexOf("-END DSA PRIVATE KEY-") !== -1 &&
+        param.indexOf("4,ENCRYPTED") !== -1) {
         var hKey = KEYUTIL.getDecryptedKeyHex(param, passcode);
         var p = ASN1HEX.getVbyList(hKey, 0, [1], "02");
         var q = ASN1HEX.getVbyList(hKey, 0, [2], "02");
@@ -1405,7 +1449,7 @@ KEYUTIL.getKey = function(param, passcode, hextype) {
     }
 
     // 11. private key by encrypted PKCS#8 hexadecimal RSA/ECDSA string
-    if (param.indexOf("-END ENCRYPTED PRIVATE KEY-") != -1) {
+    if (param.indexOf("-END ENCRYPTED PRIVATE KEY-") !== -1) {
         return KEYUTIL.getKeyFromEncryptedPKCS8PEM(param, passcode);
     }
 
@@ -1440,25 +1484,25 @@ KEYUTIL.getKey = function(param, passcode, hextype) {
  *
  */
 KEYUTIL.generateKeypair = function(alg, keylenOrCurve) {
-    if (alg == "RSA") {
+    if (alg === "RSA") {
         var keylen = keylenOrCurve;
         var prvKey = new RSAKey();
         prvKey.generate(keylen, '10001');
         prvKey.isPrivate = true;
         prvKey.isPublic = true;
-        
+
         var pubKey = new RSAKey();
         var hN = prvKey.n.toString(16);
         var hE = prvKey.e.toString(16);
         pubKey.setPublic(hN, hE);
         pubKey.isPrivate = false;
         pubKey.isPublic = true;
-        
+
         var result = {};
         result.prvKeyObj = prvKey;
         result.pubKeyObj = pubKey;
         return result;
-    } else if (alg == "EC") {
+    } else if (alg === "EC") {
         var curve = keylenOrCurve;
         var ec = new KJUR.crypto.ECDSA({curve: curve});
         var keypairHex = ec.generateKeyPairHex();
@@ -1497,18 +1541,18 @@ KEYUTIL.generateKeypair = function(alg, keylenOrCurve) {
  * <dl>
  * <dt><b>NOTE1:</b>
  * <dd>
- * PKCS#5 encrypted private key protection algorithm supports DES-CBC, 
+ * PKCS#5 encrypted private key protection algorithm supports DES-CBC,
  * DES-EDE3-CBC and AES-{128,192,256}-CBC
  * <dt><b>NOTE2:</b>
  * <dd>
  * OpenSSL supports
  * </dl>
  * @example
- * KEUUTIL.getPEM(publicKey) =&gt; generates PEM PKCS#8 public key 
+ * KEUUTIL.getPEM(publicKey) =&gt; generates PEM PKCS#8 public key
  * KEUUTIL.getPEM(privateKey, "PKCS1PRV") =&gt; generates PEM PKCS#1 plain private key
- * KEUUTIL.getPEM(privateKey, "PKCS5PRV", "pass") =&gt; generates PEM PKCS#5 encrypted private key 
+ * KEUUTIL.getPEM(privateKey, "PKCS5PRV", "pass") =&gt; generates PEM PKCS#5 encrypted private key
  *                                                          with DES-EDE3-CBC (DEFAULT)
- * KEUUTIL.getPEM(privateKey, "PKCS5PRV", "pass", "DES-CBC") =&gt; generates PEM PKCS#5 encrypted 
+ * KEUUTIL.getPEM(privateKey, "PKCS5PRV", "pass", "DES-CBC") =&gt; generates PEM PKCS#5 encrypted
  *                                                                 private key with DES-CBC
  * KEUUTIL.getPEM(privateKey, "PKCS8PRV") =&gt; generates PEM PKCS#8 plain private key
  * KEUUTIL.getPEM(privateKey, "PKCS8PRV", "pass") =&gt; generates PEM PKCS#8 encrypted private key
@@ -1533,7 +1577,7 @@ KEYUTIL.getPEM = function(keyObjOrHex, formatType, passwd, encAlg, hexType) {
             ]
         });
         return asn1Obj;
-    };
+    }
 
     function _ecdsaprv2asn1obj(keyObjOrHex) {
         var asn1Obj2 = KJUR.asn1.ASN1Util.newObject({
@@ -1545,7 +1589,7 @@ KEYUTIL.getPEM = function(keyObjOrHex, formatType, passwd, encAlg, hexType) {
             ]
         });
         return asn1Obj2;
-    };
+    }
 
     function _dsaprv2asn1obj(keyObjOrHex) {
         var asn1Obj = KJUR.asn1.ASN1Util.newObject({
@@ -1559,29 +1603,29 @@ KEYUTIL.getPEM = function(keyObjOrHex, formatType, passwd, encAlg, hexType) {
             ]
         });
         return asn1Obj;
-    };
+    }
 
     // 1. public key
 
     // x. PEM PKCS#8 public key of RSA/ECDSA/DSA public key object
-    if (((typeof RSAKey != "undefined" && keyObjOrHex instanceof RSAKey) ||
-         (typeof ns2.DSA != "undefined" && keyObjOrHex instanceof ns2.DSA) ||
-         (typeof ns2.ECDSA != "undefined" && keyObjOrHex instanceof ns2.ECDSA)) &&
-        keyObjOrHex.isPublic == true &&
-        (formatType === undefined || formatType == "PKCS8PUB")) {
+    if (((typeof RSAKey !== "undefined" && keyObjOrHex instanceof RSAKey) ||
+         (typeof ns2.DSA !== "undefined" && keyObjOrHex instanceof ns2.DSA) ||
+         (typeof ns2.ECDSA !== "undefined" && keyObjOrHex instanceof ns2.ECDSA)) &&
+        keyObjOrHex.isPublic === true &&
+        (formatType === undefined || formatType === "PKCS8PUB")) {
         var asn1Obj = new KJUR.asn1.x509.SubjectPublicKeyInfo(keyObjOrHex);
         var asn1Hex = asn1Obj.getEncodedHex();
         return ns1.ASN1Util.getPEMStringFromHex(asn1Hex, "PUBLIC KEY");
     }
-    
+
     // 2. private
 
     // x. PEM PKCS#1 plain private key of RSA private key object
-    if (formatType == "PKCS1PRV" &&
-        typeof RSAKey != "undefined" &&
+    if (formatType === "PKCS1PRV" &&
+        typeof RSAKey !== "undefined" &&
         keyObjOrHex instanceof RSAKey &&
-        (passwd === undefined || passwd == null) &&
-        keyObjOrHex.isPrivate  == true) {
+        (passwd === undefined || passwd === null) &&
+        keyObjOrHex.isPrivate === true) {
 
         var asn1Obj = _rsaprv2asn1obj(keyObjOrHex);
         var asn1Hex = asn1Obj.getEncodedHex();
@@ -1589,11 +1633,11 @@ KEYUTIL.getPEM = function(keyObjOrHex, formatType, passwd, encAlg, hexType) {
     }
 
     // x. PEM PKCS#1 plain private key of ECDSA private key object
-    if (formatType == "PKCS1PRV" &&
-        typeof RSAKey != "undefined" &&
+    if (formatType === "PKCS1PRV" &&
+        typeof RSAKey !== "undefined" &&
         keyObjOrHex instanceof KJUR.crypto.ECDSA &&
-        (passwd === undefined || passwd == null) &&
-        keyObjOrHex.isPrivate  == true) {
+        (passwd === undefined || passwd === null) &&
+        keyObjOrHex.isPrivate === true) {
 
         var asn1Obj1 = new KJUR.asn1.DERObjectIdentifier({'name': keyObjOrHex.curveName});
         var asn1Hex1 = asn1Obj1.getEncodedHex();
@@ -1607,11 +1651,11 @@ KEYUTIL.getPEM = function(keyObjOrHex, formatType, passwd, encAlg, hexType) {
     }
 
     // x. PEM PKCS#1 plain private key of DSA private key object
-    if (formatType == "PKCS1PRV" &&
-        typeof KJUR.crypto.DSA != "undefined" &&
+    if (formatType === "PKCS1PRV" &&
+        typeof KJUR.crypto.DSA !== "undefined" &&
         keyObjOrHex instanceof KJUR.crypto.DSA &&
-        (passwd === undefined || passwd == null) &&
-        keyObjOrHex.isPrivate  == true) {
+        (passwd === undefined || passwd === null) &&
+        keyObjOrHex.isPrivate === true) {
 
         var asn1Obj = _dsaprv2asn1obj(keyObjOrHex);
         var asn1Hex = asn1Obj.getEncodedHex();
@@ -1621,44 +1665,50 @@ KEYUTIL.getPEM = function(keyObjOrHex, formatType, passwd, encAlg, hexType) {
     // 3. private
 
     // x. PEM PKCS#5 encrypted private key of RSA private key object
-    if (formatType == "PKCS5PRV" &&
-        typeof RSAKey != "undefined" &&
+    if (formatType === "PKCS5PRV" &&
+        typeof RSAKey !== "undefined" &&
         keyObjOrHex instanceof RSAKey &&
-        (passwd !== undefined && passwd != null) &&
-        keyObjOrHex.isPrivate  == true) {
+        (passwd !== undefined && passwd !== null) &&
+        keyObjOrHex.isPrivate === true) {
 
         var asn1Obj = _rsaprv2asn1obj(keyObjOrHex);
         var asn1Hex = asn1Obj.getEncodedHex();
 
-        if (encAlg === undefined) encAlg = "DES-EDE3-CBC";
+        if (encAlg === undefined) {
+            encAlg = "DES-EDE3-CBC";
+        }
         return this.getEncryptedPKCS5PEMFromPrvKeyHex("RSA", asn1Hex, passwd, encAlg);
     }
 
     // x. PEM PKCS#5 encrypted private key of ECDSA private key object
-    if (formatType == "PKCS5PRV" &&
-        typeof KJUR.crypto.ECDSA != "undefined" &&
+    if (formatType === "PKCS5PRV" &&
+        typeof KJUR.crypto.ECDSA !== "undefined" &&
         keyObjOrHex instanceof KJUR.crypto.ECDSA &&
-        (passwd !== undefined && passwd != null) &&
-        keyObjOrHex.isPrivate  == true) {
+        (passwd !== undefined && passwd !== null) &&
+        keyObjOrHex.isPrivate === true) {
 
         var asn1Obj = _ecdsaprv2asn1obj(keyObjOrHex);
         var asn1Hex = asn1Obj.getEncodedHex();
 
-        if (encAlg === undefined) encAlg = "DES-EDE3-CBC";
+        if (encAlg === undefined) {
+            encAlg = "DES-EDE3-CBC";
+        }
         return this.getEncryptedPKCS5PEMFromPrvKeyHex("EC", asn1Hex, passwd, encAlg);
     }
 
     // x. PEM PKCS#5 encrypted private key of DSA private key object
-    if (formatType == "PKCS5PRV" &&
-        typeof KJUR.crypto.DSA != "undefined" &&
+    if (formatType === "PKCS5PRV" &&
+        typeof KJUR.crypto.DSA !== "undefined" &&
         keyObjOrHex instanceof KJUR.crypto.DSA &&
-        (passwd !== undefined && passwd != null) &&
-        keyObjOrHex.isPrivate  == true) {
+        (passwd !== undefined && passwd !== null) &&
+        keyObjOrHex.isPrivate === true) {
 
         var asn1Obj = _dsaprv2asn1obj(keyObjOrHex);
         var asn1Hex = asn1Obj.getEncodedHex();
 
-        if (encAlg === undefined) encAlg = "DES-EDE3-CBC";
+        if (encAlg === undefined) {
+            encAlg = "DES-EDE3-CBC";
+        }
         return this.getEncryptedPKCS5PEMFromPrvKeyHex("DSA", asn1Hex, passwd, encAlg);
     }
 
@@ -1698,12 +1748,12 @@ KEYUTIL.getPEM = function(keyObjOrHex, formatType, passwd, encAlg, hexType) {
         var encryptionSchemeAlg = "DES-EDE3-CBC";
         var encryptionSchemeIVWS = CryptoJS.lib.WordArray.random(8);
         // PBKDF2 key
-        var pbkdf2KeyWS = CryptoJS.PBKDF2(passcode, 
+        var pbkdf2KeyWS = CryptoJS.PBKDF2(passcode,
                                           pbkdf2SaltWS, { "keySize": 192/32,
                                                           "iterations": pbkdf2Iter });
         // ENCRYPT
         var plainKeyWS = CryptoJS.enc.Hex.parse(plainKeyHex);
-        var encryptedKeyHex = 
+        var encryptedKeyHex =
             CryptoJS.TripleDES.encrypt(plainKeyWS, pbkdf2KeyWS, { "iv": encryptionSchemeIVWS }) + "";
 
         //alert("encryptedKeyHex=" + encryptedKeyHex);
@@ -1719,10 +1769,10 @@ KEYUTIL.getPEM = function(keyObjOrHex, formatType, passwd, encAlg, hexType) {
     };
 
     // x. PEM PKCS#8 plain private key of RSA private key object
-    if (formatType == "PKCS8PRV" &&
-        typeof RSAKey != "undefined" &&
+    if (formatType === "PKCS8PRV" &&
+        typeof RSAKey !== "undefined" &&
         keyObjOrHex instanceof RSAKey &&
-        keyObjOrHex.isPrivate  == true) {
+        keyObjOrHex.isPrivate === true) {
 
         var keyObj = _rsaprv2asn1obj(keyObjOrHex);
         var keyHex = keyObj.getEncodedHex();
@@ -1736,7 +1786,7 @@ KEYUTIL.getPEM = function(keyObjOrHex, formatType, passwd, encAlg, hexType) {
         });
         var asn1Hex = asn1Obj.getEncodedHex();
 
-        if (passwd === undefined || passwd == null) {
+        if (passwd === undefined || passwd === null) {
             return ns1.ASN1Util.getPEMStringFromHex(asn1Hex, "PRIVATE KEY");
         } else {
             var asn1Hex2 = _getEncryptedPKCS8(asn1Hex, passwd);
@@ -1745,10 +1795,10 @@ KEYUTIL.getPEM = function(keyObjOrHex, formatType, passwd, encAlg, hexType) {
     }
 
     // x. PEM PKCS#8 plain private key of ECDSA private key object
-    if (formatType == "PKCS8PRV" &&
-        typeof KJUR.crypto.ECDSA != "undefined" &&
+    if (formatType === "PKCS8PRV" &&
+        typeof KJUR.crypto.ECDSA !== "undefined" &&
         keyObjOrHex instanceof KJUR.crypto.ECDSA &&
-        keyObjOrHex.isPrivate  == true) {
+        keyObjOrHex.isPrivate === true) {
 
         var keyObj = new KJUR.asn1.ASN1Util.newObject({
             "seq": [
@@ -1771,7 +1821,7 @@ KEYUTIL.getPEM = function(keyObjOrHex, formatType, passwd, encAlg, hexType) {
         });
 
         var asn1Hex = asn1Obj.getEncodedHex();
-        if (passwd === undefined || passwd == null) {
+        if (passwd === undefined || passwd === null) {
             return ns1.ASN1Util.getPEMStringFromHex(asn1Hex, "PRIVATE KEY");
         } else {
             var asn1Hex2 = _getEncryptedPKCS8(asn1Hex, passwd);
@@ -1780,10 +1830,10 @@ KEYUTIL.getPEM = function(keyObjOrHex, formatType, passwd, encAlg, hexType) {
     }
 
     // x. PEM PKCS#8 plain private key of DSA private key object
-    if (formatType == "PKCS8PRV" &&
-        typeof KJUR.crypto.DSA != "undefined" &&
+    if (formatType === "PKCS8PRV" &&
+        typeof KJUR.crypto.DSA !== "undefined" &&
         keyObjOrHex instanceof KJUR.crypto.DSA &&
-        keyObjOrHex.isPrivate  == true) {
+        keyObjOrHex.isPrivate === true) {
 
         var keyObj = new KJUR.asn1.DERInteger({'bigint': keyObjOrHex.x});
         var keyHex = keyObj.getEncodedHex();
@@ -1804,7 +1854,7 @@ KEYUTIL.getPEM = function(keyObjOrHex, formatType, passwd, encAlg, hexType) {
         });
 
         var asn1Hex = asn1Obj.getEncodedHex();
-        if (passwd === undefined || passwd == null) {
+        if (passwd === undefined || passwd === null) {
             return ns1.ASN1Util.getPEMStringFromHex(asn1Hex, "PRIVATE KEY");
         } else {
             var asn1Hex2 = _getEncryptedPKCS8(asn1Hex, passwd);
@@ -1866,20 +1916,24 @@ KEYUTIL.parseCSRHex = function(csrHex) {
     var h = csrHex;
 
     // 1. sequence
-    if (h.substr(0, 2) != "30")
-        throw "malformed CSR(code:001)"; // not sequence
+    if (h.substr(0, 2) !== "30") {
+        throw "malformed CSR(code:001)";
+    } // not sequence
 
     var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(h, 0);
-    if (a1.length < 1)
-        throw "malformed CSR(code:002)"; // short length
+    if (a1.length < 1) {
+        throw "malformed CSR(code:002)";
+    } // short length
 
     // 2. 2nd sequence
-    if (h.substr(a1[0], 2) != "30")
-        throw "malformed CSR(code:003)"; // not sequence
+    if (h.substr(a1[0], 2) !== "30") {
+        throw "malformed CSR(code:003)";
+    } // not sequence
 
     var a2 = ASN1HEX.getPosArrayOfChildren_AtObj(h, a1[0]);
-    if (a2.length < 3)
-        throw "malformed CSR(code:004)"; // 2nd seq short elem
+    if (a2.length < 3) {
+        throw "malformed CSR(code:004)";
+    } // 2nd seq short elem
 
     result.p8pubkeyhex = ASN1HEX.getHexOfTLV_AtObj(h, a2[2]);
 


### PR DESCRIPTION
This PR contains the following changes:
- [x] adds a jshintrc file for javascript code linter
- [x] adds `"use strict"` header in keyutil and crypto
  - some code transformers like babelify add "use strict" header by default. Code before this commit will fail to run in those environments
- [x] removes weird `new function(){}` constructs to publish "static" fields and functions
- [x] removes `eval()` in crypto-1.1.js
- [x] fixes #84 in a more elegant way
- [x] fixes a lot of jshint complaints
- [x] removes whitespaces at EOL

qunit test results are equal to the current master branch. 

Sorry for breaking the indentation ;)
