### PR TITLE
fix syntax error in crypto-1.1.js when using global strict mode

### DIFF
--- a/crypto-1.1.js
+++ b/crypto-1.1.js
@@ -26,7 +26,7 @@
  * @name KJUR
  * @namespace kjur's class library name space
  */
-if (typeof KJUR == "undefined" || !KJUR) KJUR = {};
+if (typeof KJUR == "undefined" || !KJUR) window.KJUR = {};
 /**
  * kjur's cryptographic algorithm provider library name space
  * <p>


### PR DESCRIPTION
Global KJUR variable cannot be assigned globally in strict mode. This
fix the issue in browser. If this file is used in other environment,
like node, this is a no go of course. I didn’t find doc on how to
build/test so I propose this as a 10 seconds fix tentative.

I can do better if you provide me any guidance on how to build/test the
library (and maybe have another pull request for the README).
