### PR TITLE
Fix license field in package.json.

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -28,12 +28,7 @@
     "JOSE", "JWA"
   ],
   "author": "Kenji Urushima",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://raw.github.com/kjur/jsrsasign/master/LICENSE.txt"
-    }
-  ],
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/kjur/jsrsasign/issues"
   },


### PR DESCRIPTION
This stops npm's complaining:

```bash
froatsnook@monster ~/src/jsrsasign/npm
(/・・)ノ npm install
npm WARN jsrsasign@5.0.12 No license field.
```