### PR TITLE
throw Errors instead of strings

### DIFF
--- a/asn1-1.0.js
+++ b/asn1-1.0.js
@@ -213,11 +213,11 @@ KJUR.asn1.ASN1Util = new function() {
         var ns1 = KJUR.asn1;
         var keys = Object.keys(param);
         if (keys.length != 1)
-            throw "key of param shall be only one.";
+            throw new Error("key of param shall be only one.");
         var key = keys[0];
 
         if (":bool:int:bitstr:octstr:null:oid:enum:utf8str:numstr:prnstr:telstr:ia5str:utctime:gentime:seq:set:tag:".indexOf(":" + key + ":") == -1)
-            throw "undefined key: " + key;
+            throw new Error("undefined key: " + key);
 
         if (key == "bool")    return new ns1.DERBoolean(param[key]);
         if (key == "int")     return new ns1.DERInteger(param[key]);
@@ -267,7 +267,7 @@ KJUR.asn1.ASN1Util = new function() {
                 if (tagParam.tag !== undefined)
                     newParam.tag = tagParam.tag;
                 if (tagParam.obj === undefined)
-                    throw "obj shall be specified for 'tag'.";
+                    throw new Error("obj shall be specified for 'tag'.");
                 newParam.obj = ns1.ASN1Util.newObject(tagParam.obj);
                 return new ns1.DERTaggedObject(newParam);
             }
@@ -369,7 +369,7 @@ KJUR.asn1.ASN1Util.oidIntToHex = function(oidString) {
     };
     
     if (! oidString.match(/^[0-9.]+$/)) {
-        throw "malformed oid string: " + oidString;
+        throw new Error("malformed oid string: " + oidString);
     }
     var h = '';
     var a = oidString.split('.');
@@ -416,10 +416,10 @@ KJUR.asn1.ASN1Object = function() {
      */
     this.getLengthHexFromValue = function() {
         if (typeof this.hV == "undefined" || this.hV == null) {
-            throw "this.hV is null or undefined.";
+            throw new Error("this.hV is null or undefined.");
         }
         if (this.hV.length % 2 == 1) {
-            throw "value hex must be even length: n=" + hV.length + ",v=" + this.hV;
+            throw new Error("value hex must be even length: n=" + hV.length + ",v=" + this.hV);
         }
         var n = this.hV.length / 2;
         var hN = n.toString(16);
@@ -431,7 +431,7 @@ KJUR.asn1.ASN1Object = function() {
         } else {
             var hNlen = hN.length / 2;
             if (hNlen > 15) {
-                throw "ASN.1 length too long to represent by 8x: n = " + n.toString(16);
+                throw new Error("ASN.1 length too long to represent by 8x: n = " + n.toString(16));
             }
             var head = 128 + hNlen;
             return head.toString(16) + hN;
@@ -858,7 +858,7 @@ KJUR.asn1.DERBitString = function(params) {
      */
     this.setUnusedBitsAndHexValue = function(unusedBits, hValue) {
         if (unusedBits < 0 || 7 < unusedBits) {
-            throw "unused bits shall be from 0 to 7: u = " + unusedBits;
+            throw new Error("unused bits shall be from 0 to 7: u = " + unusedBits);
         }
         var hUnusedBits = "0" + unusedBits;
         this.hTLV = null;
@@ -1051,7 +1051,7 @@ KJUR.asn1.DERObjectIdentifier = function(params) {
      */
     this.setValueOidString = function(oidString) {
         if (! oidString.match(/^[0-9.]+$/)) {
-            throw "malformed oid string: " + oidString;
+            throw new Error("malformed oid string: " + oidString);
         }
         var h = '';
         var a = oidString.split('.');
@@ -1083,7 +1083,7 @@ KJUR.asn1.DERObjectIdentifier = function(params) {
             var oid = KJUR.asn1.x509.OID.name2oidList[oidName];
             this.setValueOidString(oid);
         } else {
-            throw "DERObjectIdentifier oidName undefined: " + oidName;
+            throw new Error("DERObjectIdentifier oidName undefined: " + oidName);
         }
     };
 

--- a/asn1cades-1.0.js
+++ b/asn1cades-1.0.js
@@ -329,7 +329,7 @@ KJUR.asn1.cades.SignatureTimeStamp = function(params) {
                 params.res.match(/^[0-9A-Fa-f]+$/)) {
             } else if (params.res instanceof KJUR.asn1.ASN1Object) {
             } else {
-                throw "res param shall be ASN1Object or hex string";
+                throw new Error("res param shall be ASN1Object or hex string");
             }
         }
         if (typeof params.tst != "undefined") {
@@ -342,7 +342,7 @@ KJUR.asn1.cades.SignatureTimeStamp = function(params) {
                 this.valueList = [d];
             } else if (params.tst instanceof KJUR.asn1.ASN1Object) {
             } else {
-                throw "tst param shall be ASN1Object or hex string";
+                throw new Error("tst param shall be ASN1Object or hex string");
             }
         }
     }
@@ -446,7 +446,7 @@ KJUR.asn1.cades.OtherCertID = function(params) {
     this.getEncodedHex = function() {
         if (this.hTLV != null) return this.hTLV;
         if (this.dOtherCertHash == null)
-            throw "otherCertHash not set";
+            throw new Error("otherCertHash not set");
         var a = [this.dOtherCertHash];
         if (this.dIssuerSerial != null)
             a.push(this.dIssuerSerial);
@@ -512,7 +512,7 @@ KJUR.asn1.cades.OtherHash = function(params) {
      */
     this.setByCertPEM = function(certPEM) {
         if (certPEM.indexOf("-----BEGIN ") == -1)
-            throw "certPEM not to seem PEM format";
+            throw new Error("certPEM not to seem PEM format");
         var hex = X509.pemToHex(certPEM);
         var hash = KJUR.crypto.Util.hashHex(hex, this.alg);
         this.dOtherHash = 
@@ -521,7 +521,7 @@ KJUR.asn1.cades.OtherHash = function(params) {
 
     this.getEncodedHex = function() {
         if (this.dOtherHash == null)
-            throw "OtherHash not set";
+            throw new Error("OtherHash not set");
         return this.dOtherHash.getEncodedHex();
     };
 
@@ -532,7 +532,7 @@ KJUR.asn1.cades.OtherHash = function(params) {
             } else if (params.match(/^[0-9A-Fa-f]+$/)) {
                 this.dOtherHash = new nA.DEROctetString({hex: params});
             } else {
-                throw "unsupported string value for params";
+                throw new Error("unsupported string value for params");
             }
         } else if (typeof params == "object") {
             if (typeof params.cert == "string") {
@@ -598,12 +598,12 @@ KJUR.asn1.cades.CAdESUtil.parseSignedDataForAddingUnsigned = function(hex) {
     // 1. not oid signed-data then error
     if (ASN1HEX.getDecendantHexTLVByNthList(hex, 0, [0]) != 
         "06092a864886f70d010702")
-        throw "hex is not CMS SignedData";
+        throw new Error("hex is not CMS SignedData");
 
     var iSD = ASN1HEX.getDecendantIndexByNthList(hex, 0, [1, 0]);
     var aSDChildIdx = ASN1HEX.getPosArrayOfChildren_AtObj(hex, iSD);
     if (aSDChildIdx.length < 4)
-        throw "num of SignedData elem shall be 4 at least";
+        throw new Error("num of SignedData elem shall be 4 at least");
 
     // 2. HEXs of SignedData children
     // 2.1. SignedData.CMSVersion
@@ -638,7 +638,7 @@ KJUR.asn1.cades.CAdESUtil.parseSignedDataForAddingUnsigned = function(hex) {
     // 2.6. SignerInfos
     var iSignerInfos = iNext;
     if (hex.substr(iSignerInfos, 2) != "31")
-        throw "Can't find signerInfos";
+        throw new Error("Can't find signerInfos");
 
     var aSIIndex = ASN1HEX.getPosArrayOfChildren_AtObj(hex, iSignerInfos);
     //alert(aSIIndex.join("-"));
@@ -713,7 +713,7 @@ KJUR.asn1.cades.CAdESUtil.parseSignerInfoForAddingUnsigned =
     //alert(aSIChildIdx.join("="));
 
     if (aSIChildIdx.length != 6)
-        throw "not supported items for SignerInfo (!=6)"; 
+        throw new Error("not supported items for SignerInfo (!=6)"); 
 
     // 1. SignerInfo.CMSVersion
     var iVersion = aSIChildIdx.shift();

--- a/asn1cms-1.0.js
+++ b/asn1cms-1.0.js
@@ -102,14 +102,14 @@ KJUR.asn1.cms.Attribute = function(params) {
         try {
             attrValueASN1.getEncodedHex();
         } catch (ex) {
-            throw "fail valueSet.getEncodedHex in Attribute(1)/" + ex;
+            throw new Error("fail valueSet.getEncodedHex in Attribute(1)/" + ex);
         }
 
         seq = new KJUR.asn1.DERSequence({"array": [attrTypeASN1, attrValueASN1]});
         try {
             this.hTLV = seq.getEncodedHex();
         } catch (ex) {
-            throw "failed seq.getEncodedHex in Attribute(2)/" + ex;
+            throw new Error("failed seq.getEncodedHex in Attribute(2)/" + ex);
         }
 
         return this.hTLV;
@@ -221,7 +221,7 @@ KJUR.asn1.cms.SigningTime = function(params) {
         try {
             asn1.getEncodedHex();
         } catch (ex) {
-            throw "SigningTime.getEncodedHex() failed/" + ex;
+            throw new Error("SigningTime.getEncodedHex() failed/" + ex);
         }
         this.valueList = [asn1];
     }
@@ -630,7 +630,7 @@ KJUR.asn1.cms.SignerInfo = function(params) {
         //alert("sattrs.hTLV=" + this.dSignedAttrs.hTLV);
         if (this.dSignedAttrs instanceof KJUR.asn1.cms.AttributeList &&
             this.dSignedAttrs.length() == 0) {
-            throw "SignedAttrs length = 0 (empty)";
+            throw new Error("SignedAttrs length = 0 (empty)");
         }
         var sa = new nA.DERTaggedObject({obj: this.dSignedAttrs,
                                          tag: 'a0', explicit: false});
@@ -718,7 +718,7 @@ KJUR.asn1.cms.EncapsulatedContentInfo = function(params) {
 
     this.getEncodedHex = function() {
         if (typeof this.eContentValueHex != "string") {
-            throw "eContentValue not yet set";
+            throw new Error("eContentValue not yet set");
         }
 
         var dValue = new nA.DEROctetString({hex: this.eContentValueHex});

--- a/asn1csr-1.0.js
+++ b/asn1csr-1.0.js
@@ -135,7 +135,7 @@ KJUR.asn1.csr.CertificationRequest = function(params) {
 
     this.getEncodedHex = function() {
         if (this.isModified == false && this.hTLV != null) return this.hTLV;
-        throw "not signed yet";
+        throw new Error("not signed yet");
     };
 
     if (typeof params != "undefined") {
@@ -291,10 +291,10 @@ KJUR.asn1.csr.CSRUtil = new function() {
 KJUR.asn1.csr.CSRUtil.newCSRPEM = function(param) {
     var ns1 = KJUR.asn1.csr;
 
-    if (param.subject === undefined) throw "parameter subject undefined";
-    if (param.sbjpubkey === undefined) throw "parameter sbjpubkey undefined";
-    if (param.sigalg === undefined) throw "parameter sigalg undefined";
-    if (param.sbjprvkey === undefined) throw "parameter sbjpubkey undefined";
+    if (param.subject === undefined) throw new Error("parameter subject undefined");
+    if (param.sbjpubkey === undefined) throw new Error("parameter sbjpubkey undefined");
+    if (param.sigalg === undefined) throw new Error("parameter sigalg undefined");
+    if (param.sbjprvkey === undefined) throw new Error("parameter sbjpubkey undefined");
 
     var csri = new ns1.CertificationRequestInfo();
     csri.setSubjectByParam(param.subject);

--- a/asn1hex-1.1.js
+++ b/asn1hex-1.1.js
@@ -316,12 +316,12 @@ var ASN1HEX = new function() {
 ASN1HEX.getVbyList = function(h, currentIndex, nthList, checkingTag) {
     var idx = this.getDecendantIndexByNthList(h, currentIndex, nthList);
     if (idx === undefined) {
-        throw "can't find nthList object";
+        throw new Error("can't find nthList object");
     }
     if (checkingTag !== undefined) {
         if (h.substr(idx, 2) != checkingTag) {
-            throw "checking tag doesn't match: " + 
-                h.substr(idx,2) + "!=" + checkingTag;
+            throw new Error("checking tag doesn't match: " + 
+                h.substr(idx,2) + "!=" + checkingTag);
         }
     }
     return this.getHexOfV_AtObj(h, idx);

--- a/asn1tsp-1.0.js
+++ b/asn1tsp-1.0.js
@@ -205,7 +205,7 @@ KJUR.asn1.tsp.TimeStampReq = function(params) {
 
     this.getEncodedHex = function() {
         if (this.dMessageImprint == null)
-            throw "messageImprint shall be specified";
+            throw new Error("messageImprint shall be specified");
 
         var a = [this.dVersion, this.dMessageImprint];
         if (this.dPolicy != null) a.push(this.dPolicy);
@@ -285,19 +285,19 @@ KJUR.asn1.tsp.TSTInfo = function(params) {
     this.getEncodedHex = function() {
         var a = [this.dVersion];
 
-        if (this.dPolicy == null) throw "policy shall be specified.";
+        if (this.dPolicy == null) throw new Error("policy shall be specified.");
         a.push(this.dPolicy);
 
         if (this.dMessageImprint == null)
-            throw "messageImprint shall be specified.";
+            throw new Error("messageImprint shall be specified.");
         a.push(this.dMessageImprint);
 
         if (this.dSerialNumber == null)
-            throw "serialNumber shall be specified.";
+            throw new Error("serialNumber shall be specified.");
         a.push(this.dSerialNumber);
 
         if (this.dGenTime == null)
-            throw "genTime shall be specified.";
+            throw new Error("genTime shall be specified.");
         a.push(this.dGenTime);
 
         if (this.dAccuracy != null) a.push(this.dAccuracy);
@@ -313,7 +313,7 @@ KJUR.asn1.tsp.TSTInfo = function(params) {
     if (typeof params != "undefined") {
         if (typeof params.policy == "string") {
             if (! params.policy.match(/^[0-9.]+$/))
-                throw "policy shall be oid like 0.1.4.134";
+                throw new Error("policy shall be oid like 0.1.4.134");
             this.dPolicy = new nA.DERObjectIdentifier({oid: params.policy});
         }
         if (typeof params.messageImprint != "undefined") {
@@ -365,7 +365,7 @@ KJUR.asn1.tsp.TimeStampResp = function(params) {
 
     this.getEncodedHex = function() {
         if (this.dStatus == null)
-            throw "status shall be specified";
+            throw new Error("status shall be specified");
         var a = [this.dStatus];
         if (this.dTST != null) a.push(this.dTST);
         var seq = new nA.DERSequence({array: a});
@@ -412,7 +412,7 @@ KJUR.asn1.tsp.PKIStatusInfo = function(params) {
 
     this.getEncodedHex = function() {
         if (this.dStatus == null)
-            throw "status shall be specified";
+            throw new Error("status shall be specified");
         var a = [this.dStatus];
         if (this.dStatusString != null) a.push(this.dStatusString);
         if (this.dFailureInfo != null) a.push(this.dFailureInfo);
@@ -470,7 +470,7 @@ KJUR.asn1.tsp.PKIStatus = function(params) {
         if (typeof params.name != "undefined") {
             var list = nT.PKIStatus.valueList;
             if (typeof list[params.name] == "undefined")
-                throw "name undefined: " + params.name;
+                throw new Error("name undefined: " + params.name);
             this.dStatus = 
                 new nA.DERInteger({'int': list[params.name]});
         } else {
@@ -553,7 +553,7 @@ KJUR.asn1.tsp.PKIFailureInfo = function(params) {
 
     this.getEncodedHex = function() {
         if (this.value == null)
-            throw "value shall be specified";
+            throw new Error("value shall be specified");
         var binValue = new Number(this.value).toString(2);
         var dValue = new nA.DERBitString();
         dValue.setByBinaryString(binValue);
@@ -565,7 +565,7 @@ KJUR.asn1.tsp.PKIFailureInfo = function(params) {
         if (typeof params.name == "string") {
             var list = nT.PKIFailureInfo.valueList;
             if (typeof list[params.name] == "undefined")
-                throw "name undefined: " + params.name;
+                throw new Error("name undefined: " + params.name);
             this.value = list[params.name];
         } else if (typeof params['int'] == "number") {
             this.value = params['int'];
@@ -597,7 +597,7 @@ KJUR.asn1.tsp.PKIFailureInfo.valueList = {
  */
 KJUR.asn1.tsp.AbstractTSAAdapter = function(params) {
     this.getTSTHex = function(msgHex, hashAlg) {
-        throw "not implemented yet";
+        throw new Error("not implemented yet");
     };
 };
 
@@ -754,7 +754,7 @@ KJUR.asn1.tsp.TSPUtil.parseTimeStampReq = function(reqHex) {
     var idxList = ASN1HEX.getPosArrayOfChildren_AtObj(reqHex, 0);
 
     if (idxList.length < 2)
-        throw "TimeStampReq must have at least 2 items";
+        throw new Error("TimeStampReq must have at least 2 items");
 
     var miHex = ASN1HEX.getHexOfTLV_AtObj(reqHex, idxList[1]);
     json.mi = KJUR.asn1.tsp.TSPUtil.parseMessageImprint(miHex); 
@@ -797,7 +797,7 @@ KJUR.asn1.tsp.TSPUtil.parseMessageImprint = function(miHex) {
     var json = {};
 
     if (miHex.substr(0, 2) != "30")
-        throw "head of messageImprint hex shall be '30'";
+        throw new Error("head of messageImprint hex shall be '30'");
 
     var idxList = ASN1HEX.getPosArrayOfChildren_AtObj(miHex, 0);
     var hashAlgOidIdx = 
@@ -806,7 +806,7 @@ KJUR.asn1.tsp.TSPUtil.parseMessageImprint = function(miHex) {
     var hashAlgOid = ASN1HEX.hextooidstr(hashAlgHex);
     var hashAlgName = KJUR.asn1.x509.OID.oid2name(hashAlgOid);
     if (hashAlgName == '')
-        throw "hashAlg name undefined: " + hashAlgOid;
+        throw new Error("hashAlg name undefined: " + hashAlgOid);
     var hashAlg = hashAlgName;
 
     var hashValueIdx =

--- a/asn1x509-1.0.js
+++ b/asn1x509-1.0.js
@@ -194,7 +194,7 @@ KJUR.asn1.x509.Certificate = function(params) {
 
     this.getEncodedHex = function() {
         if (this.isModified == false && this.hTLV != null) return this.hTLV;
-        throw "not signed yet";
+        throw new Error("not signed yet");
     };
 
     /**
@@ -445,13 +445,13 @@ KJUR.asn1.x509.TBSCertificate = function(params) {
             var extObj = new KJUR.asn1.x509.AuthorityKeyIdentifier(extParams);
             this.appendExtension(extObj);
         } else {
-            throw "unsupported extension name: " + name;
+            throw new Error("unsupported extension name: " + name);
         }
     };
 
     this.getEncodedHex = function() {
         if (this.asn1NotBefore == null || this.asn1NotAfter == null)
-            throw "notBefore and/or notAfter not set";
+            throw new Error("notBefore and/or notAfter not set");
         var asn1Validity = 
             new KJUR.asn1.DERSequence({'array':[this.asn1NotBefore, this.asn1NotAfter]});
 
@@ -868,7 +868,7 @@ KJUR.asn1.x509.CRL = function(params) {
 
     this.getEncodedHex = function() {
         if (this.isModified == false && this.hTLV != null) return this.hTLV;
-        throw "not signed yet";
+        throw new Error("not signed yet");
     };
 
     /**
@@ -1268,7 +1268,7 @@ KJUR.asn1.x509.AttributeTypeAndValue = function(params) {
         if (attrTypeAndValueStr.match(/^([^=]+)=(.+)$/)) {
             this.setByAttrTypeAndValueStr(RegExp.$1, RegExp.$2);
         } else {
-            throw "malformed attrTypeAndValueStr: " + attrTypeAndValueStr;
+            throw new Error("malformed attrTypeAndValueStr: " + attrTypeAndValueStr);
         }
     };
 
@@ -1284,7 +1284,7 @@ KJUR.asn1.x509.AttributeTypeAndValue = function(params) {
         if (dsType == "prn")    return new KJUR.asn1.DERPrintableString({"str": valueStr});
         if (dsType == "tel")    return new KJUR.asn1.DERTeletexString({"str": valueStr});
         if (dsType == "ia5")    return new KJUR.asn1.DERIA5String({"str": valueStr});
-        throw "unsupported directory string type: type=" + dsType + " value=" + valueStr;
+        throw new Error("unsupported directory string type: type=" + dsType + " value=" + valueStr);
     };
 
     this.getEncodedHex = function() {
@@ -1349,7 +1349,7 @@ KJUR.asn1.x509.SubjectPublicKeyInfo = function(params) {
      */
     this.setRSAKey = function(rsaKey) {
         if (! RSAKey.prototype.isPrototypeOf(rsaKey))
-            throw "argument is not RSAKey instance";
+            throw new Error("argument is not RSAKey instance");
         this.rsaKey = rsaKey;
         var asn1RsaN = new KJUR.asn1.DERInteger({'bigint': rsaKey.n});
         var asn1RsaE = new KJUR.asn1.DERInteger({'int': rsaKey.e});
@@ -1386,7 +1386,7 @@ KJUR.asn1.x509.SubjectPublicKeyInfo = function(params) {
             rsaKey.setPublic(a3[0], a3[1]);
             this.setRSAKey(rsaKey);
         } else {
-            throw "key not supported";
+            throw new Error("key not supported");
         }
     };
 
@@ -1395,7 +1395,7 @@ KJUR.asn1.x509.SubjectPublicKeyInfo = function(params) {
      */
     this.getASN1Object = function() {
         if (this.asn1AlgId == null || this.asn1SubjPKey == null)
-            throw "algId and/or subjPubKey not set";
+            throw new Error("algId and/or subjPubKey not set");
         var o = new KJUR.asn1.DERSequence({'array':
                                            [this.asn1AlgId, this.asn1SubjPKey]});
         return o;
@@ -1530,7 +1530,7 @@ KJUR.asn1.x509.AlgorithmIdentifier = function(params) {
 
     this.getEncodedHex = function() {
         if (this.nameAlg == null && this.asn1Alg == null) {
-            throw "algorithm not specified";
+            throw new Error("algorithm not specified");
         }
         if (this.nameAlg != null && this.asn1Alg == null) {
             this.asn1Alg = KJUR.asn1.x509.OID.name2obj(this.nameAlg);
@@ -1636,7 +1636,7 @@ KJUR.asn1.x509.GeneralName = function(params) {
 		    if (certStr.indexOf("-----BEGIN ") != -1) {
 				certHex = X509.pemToHex(certStr);
 			}
-		    if (certHex == null) throw "certissuer param not cert";
+		    if (certHex == null) throw new Error("certissuer param not cert");
 			var x = new X509();
 			x.hex = certHex;
 			var dnHex = x.getIssuerHex();
@@ -1654,7 +1654,7 @@ KJUR.asn1.x509.GeneralName = function(params) {
 		    if (certStr.indexOf("-----BEGIN ") != -1) {
 				certHex = X509.pemToHex(certStr);
 			}
-		    if (certHex == null) throw "certsubj param not cert";
+		    if (certHex == null) throw new Error("certsubj param not cert");
 			var x = new X509();
 			x.hex = certHex;
 			var dnHex = x.getSubjectHex();
@@ -1663,7 +1663,7 @@ KJUR.asn1.x509.GeneralName = function(params) {
 		}
 
         if (this.type == null)
-            throw "unsupported type in params=" + params;
+            throw new Error("unsupported type in params=" + params);
         this.asn1Obj = new KJUR.asn1.DERTaggedObject({'explicit': this.explicit,
                                                       'tag': pTag[this.type],
                                                       'obj': v});
@@ -1744,7 +1744,7 @@ KJUR.asn1.x509.DistributionPointName = function(gnOrRdn) {
 
     this.getEncodedHex = function() {
         if (this.type != "full")
-            throw "currently type shall be 'full': " + this.type;
+            throw new Error("currently type shall be 'full': " + this.type);
         this.asn1Obj = new KJUR.asn1.DERTaggedObject({'explicit': false,
                                                       'tag': this.tag,
                                                       'obj': this.asn1V});
@@ -1758,7 +1758,7 @@ KJUR.asn1.x509.DistributionPointName = function(gnOrRdn) {
             this.tag = "a0";
             this.asn1V = gnOrRdn;
         } else {
-            throw "This class supports GeneralNames only as argument";
+            throw new Error("This class supports GeneralNames only as argument");
         }
     }
 };
@@ -1917,7 +1917,7 @@ KJUR.asn1.x509.OID = new function(params) {
         if (typeof this.objCache[name] != "undefined")
             return this.objCache[name];
         if (typeof this.name2oidList[name] == "undefined")
-            throw "Name of ObjectIdentifier not defined: " + name;
+            throw new Error("Name of ObjectIdentifier not defined: " + name);
         var oid = this.name2oidList[name];
         var obj = new KJUR.asn1.DERObjectIdentifier({'oid': oid});
         this.objCache[name] = obj;
@@ -1938,7 +1938,7 @@ KJUR.asn1.x509.OID = new function(params) {
         if (typeof this.objCache[atype] != "undefined")
             return this.objCache[atype];
         if (typeof this.atype2oidList[atype] == "undefined")
-            throw "AttributeType name undefined: " + atype;
+            throw new Error("AttributeType name undefined: " + atype);
         var oid = this.atype2oidList[atype];
         var obj = new KJUR.asn1.DERObjectIdentifier({'oid': oid});
         this.objCache[atype] = obj;
@@ -2087,37 +2087,37 @@ KJUR.asn1.x509.X509Util.newCertPEM = function(param) {
     if (param.serial !== undefined)
         o.setSerialNumberByParam(param.serial);
     else
-        throw "serial number undefined.";
+        throw new Error("serial number undefined.");
 
     if (typeof param.sigalg.name == 'string')
         o.setSignatureAlgByParam(param.sigalg);
     else 
-        throw "unproper signature algorithm name";
+        throw new Error("unproper signature algorithm name");
 
     if (param.issuer !== undefined)
         o.setIssuerByParam(param.issuer);
     else
-        throw "issuer name undefined.";
+        throw new Error("issuer name undefined.");
     
     if (param.notbefore !== undefined)
         o.setNotBeforeByParam(param.notbefore);
     else
-        throw "notbefore undefined.";
+        throw new Error("notbefore undefined.");
 
     if (param.notafter !== undefined)
         o.setNotAfterByParam(param.notafter);
     else
-        throw "notafter undefined.";
+        throw new Error("notafter undefined.");
 
     if (param.subject !== undefined)
         o.setSubjectByParam(param.subject);
     else
-        throw "subject name undefined.";
+        throw new Error("subject name undefined.");
 
     if (param.sbjpubkey !== undefined)
         o.setSubjectPublicKeyByGetKey(param.sbjpubkey);
     else
-        throw "subject public key undefined.";
+        throw new Error("subject public key undefined.");
 
     if (param.ext !== undefined && param.ext.length !== undefined) {
         for (var i = 0; i < param.ext.length; i++) {
@@ -2129,7 +2129,7 @@ KJUR.asn1.x509.X509Util.newCertPEM = function(param) {
 
     // set signature
     if (param.cakey === undefined && param.sighex === undefined)
-        throw "param cakey and sighex undefined.";
+        throw new Error("param cakey and sighex undefined.");
 
     var caKey = null;
     var cert = null;

--- a/base64x-1.1.js
+++ b/base64x-1.1.js
@@ -430,13 +430,13 @@ function intarystrtohex(s) {
   try {
     var hex = s.split(/,/).map(function(element, index, array) {
       var i = parseInt(element);
-      if (i < 0 || 255 < i) throw "integer not in range 0-255";
+      if (i < 0 || 255 < i) throw new Error("integer not in range 0-255");
       var hI = ("00" + i.toString(16)).slice(-2);
       return hI;
     }).join('');
     return hex;
   } catch(ex) {
-    throw "malformed integer array string: " + ex;
+    throw new Error("malformed integer array string: " + ex);
   }
 }
 

--- a/crypto-1.1.js
+++ b/crypto-1.1.js
@@ -135,7 +135,7 @@ KJUR.crypto.Util = new function() {
      */
     this.getDigestInfoHex = function(hHash, alg) {
 	if (typeof this.DIGESTINFOHEAD[alg] == "undefined")
-	    throw "alg not supported in Util.DIGESTINFOHEAD: " + alg;
+	    throw new Error("alg not supported in Util.DIGESTINFOHEAD: " + alg);
 	return this.DIGESTINFOHEAD[alg] + hHash;
     };
 
@@ -154,7 +154,7 @@ KJUR.crypto.Util = new function() {
 	var pmStrLen = keySize / 4; // minimum PM length
 
 	if (hDigestInfo.length + 22 > pmStrLen) // len(0001+ff(*8)+00+hDigestInfo)=22
-	    throw "key is too short for SigAlg: keylen=" + keySize + "," + alg;
+	    throw new Error("key is too short for SigAlg: keylen=" + keySize + "," + alg);
 
 	var hHead = "0001";
 	var hTail = "00" + hDigestInfo;
@@ -342,7 +342,7 @@ KJUR.crypto.MessageDigest = function(params) {
 	    try {
 		this.md = KJUR.crypto.Util.CRYPTOJSMESSAGEDIGESTNAME[alg].create();
 	    } catch (ex) {
-		throw "setAlgAndProvider hash alg set fail alg=" + alg + "/" + ex;
+		throw new Error("setAlgAndProvider hash alg set fail alg=" + alg + "/" + ex);
 	    }
 	    this.updateString = function(str) {
 		this.md.update(str);
@@ -369,7 +369,7 @@ KJUR.crypto.MessageDigest = function(params) {
 	    try {
 		this.md = new sjcl.hash.sha256();
 	    } catch (ex) {
-		throw "setAlgAndProvider hash alg set fail alg=" + alg + "/" + ex;
+		throw new Error("setAlgAndProvider hash alg set fail alg=" + alg + "/" + ex);
 	    }
 	    this.updateString = function(str) {
 		this.md.update(str);
@@ -404,7 +404,7 @@ KJUR.crypto.MessageDigest = function(params) {
      * md.updateString('New York');
      */
     this.updateString = function(str) {
-	throw "updateString(str) not supported for this alg/prov: " + this.algName + "/" + this.provName;
+	throw new Error("updateString(str) not supported for this alg/prov: " + this.algName + "/" + this.provName);
     };
 
     /**
@@ -418,7 +418,7 @@ KJUR.crypto.MessageDigest = function(params) {
      * md.updateHex('0afe36');
      */
     this.updateHex = function(hex) {
-	throw "updateHex(hex) not supported for this alg/prov: " + this.algName + "/" + this.provName;
+	throw new Error("updateHex(hex) not supported for this alg/prov: " + this.algName + "/" + this.provName);
     };
 
     /**
@@ -431,7 +431,7 @@ KJUR.crypto.MessageDigest = function(params) {
      * md.digest()
      */
     this.digest = function() {
-	throw "digest() not supported for this alg/prov: " + this.algName + "/" + this.provName;
+	throw new Error("digest() not supported for this alg/prov: " + this.algName + "/" + this.provName);
     };
 
     /**
@@ -445,7 +445,7 @@ KJUR.crypto.MessageDigest = function(params) {
      * md.digestString('aaa')
      */
     this.digestString = function(str) {
-	throw "digestString(str) not supported for this alg/prov: " + this.algName + "/" + this.provName;
+	throw new Error("digestString(str) not supported for this alg/prov: " + this.algName + "/" + this.provName);
     };
 
     /**
@@ -459,7 +459,7 @@ KJUR.crypto.MessageDigest = function(params) {
      * md.digestHex('0f2abd')
      */
     this.digestHex = function(hex) {
-	throw "digestHex(hex) not supported for this alg/prov: " + this.algName + "/" + this.provName;
+	throw new Error("digestHex(hex) not supported for this alg/prov: " + this.algName + "/" + this.provName);
     };
 
     if (params !== undefined) {
@@ -523,7 +523,7 @@ KJUR.crypto.Mac = function(params) {
 
 	alg = alg.toLowerCase();
         if (alg.substr(0, 4) != "hmac") {
-	    throw "setAlgAndProvider unsupported HMAC alg: " + alg;
+	    throw new Error("setAlgAndProvider unsupported HMAC alg: " + alg);
 	}
 
 	if (prov === undefined) prov = KJUR.crypto.Util.DEFAULTPROVIDER[alg];
@@ -538,7 +538,7 @@ KJUR.crypto.Mac = function(params) {
 		var mdObj = KJUR.crypto.Util.CRYPTOJSMESSAGEDIGESTNAME[hashAlg];
 		this.mac = CryptoJS.algo.HMAC.create(mdObj, this.pass);
 	    } catch (ex) {
-		throw "setAlgAndProvider hash alg set fail hashAlg=" + hashAlg + "/" + ex;
+		throw new Error("setAlgAndProvider hash alg set fail hashAlg=" + hashAlg + "/" + ex);
 	    }
 	    this.updateString = function(str) {
 		this.mac.update(str);
@@ -573,7 +573,7 @@ KJUR.crypto.Mac = function(params) {
      * md.updateString('New York');
      */
     this.updateString = function(str) {
-	throw "updateString(str) not supported for this alg/prov: " + this.algProv;
+	throw new Error("updateString(str) not supported for this alg/prov: " + this.algProv);
     };
 
     /**
@@ -587,7 +587,7 @@ KJUR.crypto.Mac = function(params) {
      * md.updateHex('0afe36');
      */
     this.updateHex = function(hex) {
-	throw "updateHex(hex) not supported for this alg/prov: " + this.algProv;
+	throw new Error("updateHex(hex) not supported for this alg/prov: " + this.algProv);
     };
 
     /**
@@ -600,7 +600,7 @@ KJUR.crypto.Mac = function(params) {
      * md.digest()
      */
     this.doFinal = function() {
-	throw "digest() not supported for this alg/prov: " + this.algProv;
+	throw new Error("digest() not supported for this alg/prov: " + this.algProv);
     };
 
     /**
@@ -614,7 +614,7 @@ KJUR.crypto.Mac = function(params) {
      * md.digestString('aaa')
      */
     this.doFinalString = function(str) {
-	throw "digestString(str) not supported for this alg/prov: " + this.algProv;
+	throw new Error("digestString(str) not supported for this alg/prov: " + this.algProv);
     };
 
     /**
@@ -629,7 +629,7 @@ KJUR.crypto.Mac = function(params) {
      * md.digestHex('0f2abd')
      */
     this.doFinalHex = function(hex) {
-	throw "digestHex(hex) not supported for this alg/prov: " + this.algProv;
+	throw new Error("digestHex(hex) not supported for this alg/prov: " + this.algProv);
     };
 
     /**
@@ -691,12 +691,12 @@ KJUR.crypto.Mac = function(params) {
 	}
 
 	if (typeof pass != 'object')
-	    throw "KJUR.crypto.Mac unsupported password type: " + pass;
+	    throw new Error("KJUR.crypto.Mac unsupported password type: " + pass);
 	
 	var hPass = null;
 	if (pass.hex  !== undefined) {
 	    if (pass.hex.length % 2 != 0 || ! pass.hex.match(/^[0-9A-Fa-f]+$/))
-		throw "Mac: wrong hex password: " + pass.hex;
+		throw new Error("Mac: wrong hex password: " + pass.hex);
 	    hPass = pass.hex;
 	}
 	if (pass.utf8 !== undefined) hPass = utf8tohex(pass.utf8);
@@ -705,7 +705,7 @@ KJUR.crypto.Mac = function(params) {
 	if (pass.b64u !== undefined) hPass = b64utohex(pass.b64u);
 
 	if (hPass == null)
-	    throw "KJUR.crypto.Mac unsupported password type: " + pass;
+	    throw new Error("KJUR.crypto.Mac unsupported password type: " + pass);
 
 	this.pass = CryptoJS.enc.Hex.parse(hPass);
     };
@@ -847,14 +847,14 @@ KJUR.crypto.Signature = function(params) {
     this.setAlgAndProvider = function(alg, prov) {
 	this._setAlgNames();
 	if (prov != 'cryptojs/jsrsa')
-	    throw "provider not supported: " + prov;
+	    throw new Error("provider not supported: " + prov);
 
 	if (':md5:sha1:sha224:sha256:sha384:sha512:ripemd160:'.indexOf(this.mdAlgName) != -1) {
 	    try {
 		this.md = new KJUR.crypto.MessageDigest({'alg':this.mdAlgName});
 	    } catch (ex) {
-		throw "setAlgAndProvider hash alg set fail alg=" +
-                      this.mdAlgName + "/" + ex;
+		throw new Error("setAlgAndProvider hash alg set fail alg=" +
+                      this.mdAlgName + "/" + ex);
 	    }
 
 	    this.init = function(keyparam, pass) {
@@ -866,7 +866,7 @@ KJUR.crypto.Signature = function(params) {
 			keyObj = KEYUTIL.getKey(keyparam, pass);
 		    }
 		} catch (ex) {
-		    throw "init failed:" + ex;
+		    throw new Error("init failed:" + ex);
 		}
 
 		if (keyObj.isPrivate === true) {
@@ -876,7 +876,7 @@ KJUR.crypto.Signature = function(params) {
 		    this.pubKey = keyObj;
 		    this.state = "VERIFY";
 		} else {
-		    throw "init failed.:" + keyObj;
+		    throw new Error("init failed.:" + keyObj);
 		}
 	    };
 
@@ -939,7 +939,7 @@ KJUR.crypto.Signature = function(params) {
 		} else if (this.prvKey instanceof KJUR.crypto.DSA) {
 		    this.hSign = this.prvKey.signWithMessageHash(this.sHashHex);
 		} else {
-		    throw "Signature: unsupported public key alg: " + this.pubkeyAlgName;
+		    throw new Error("Signature: unsupported public key alg: " + this.pubkeyAlgName);
 		}
 		return this.hSign;
 	    };
@@ -970,7 +970,7 @@ KJUR.crypto.Signature = function(params) {
 		} else if (this.pubKey instanceof KJUR.crypto.DSA) {
 		    return this.pubKey.verifyWithMessageHash(this.sHashHex, hSigVal);
 		} else {
-		    throw "Signature: unsupported public key alg: " + this.pubkeyAlgName;
+		    throw new Error("Signature: unsupported public key alg: " + this.pubkeyAlgName);
 		}
 	    };
 	}
@@ -1012,8 +1012,8 @@ KJUR.crypto.Signature = function(params) {
      * sig.init(sCertPEM)
      */
     this.init = function(key, pass) {
-	throw "init(key, pass) not supported for this alg:prov=" +
-	      this.algProvName;
+	throw new Error("init(key, pass) not supported for this alg:prov=" +
+	      this.algProvName);
     };
 
     /**
@@ -1037,8 +1037,8 @@ KJUR.crypto.Signature = function(params) {
      * sig.initVerifyByPublicKey(rsaPrvKey)
      */
     this.initVerifyByPublicKey = function(rsaPubKey) {
-	throw "initVerifyByPublicKey(rsaPubKeyy) not supported for this alg:prov=" +
-	      this.algProvName;
+	throw new Error("initVerifyByPublicKey(rsaPubKeyy) not supported for this alg:prov=" +
+	      this.algProvName);
     };
 
     /**
@@ -1054,8 +1054,8 @@ KJUR.crypto.Signature = function(params) {
      * sig.initVerifyByCertificatePEM(certPEM)
      */
     this.initVerifyByCertificatePEM = function(certPEM) {
-	throw "initVerifyByCertificatePEM(certPEM) not supported for this alg:prov=" +
-	    this.algProvName;
+	throw new Error("initVerifyByCertificatePEM(certPEM) not supported for this alg:prov=" +
+	    this.algProvName);
     };
 
     /**
@@ -1077,7 +1077,7 @@ KJUR.crypto.Signature = function(params) {
      * sig.initSign(prvKey)
      */
     this.initSign = function(prvKey) {
-	throw "initSign(prvKey) not supported for this alg:prov=" + this.algProvName;
+	throw new Error("initSign(prvKey) not supported for this alg:prov=" + this.algProvName);
     };
 
     /**
@@ -1091,7 +1091,7 @@ KJUR.crypto.Signature = function(params) {
      * sig.updateString('aaa')
      */
     this.updateString = function(str) {
-	throw "updateString(str) not supported for this alg:prov=" + this.algProvName;
+	throw new Error("updateString(str) not supported for this alg:prov=" + this.algProvName);
     };
 
     /**
@@ -1105,7 +1105,7 @@ KJUR.crypto.Signature = function(params) {
      * sig.updateHex('1f2f3f')
      */
     this.updateHex = function(hex) {
-	throw "updateHex(hex) not supported for this alg:prov=" + this.algProvName;
+	throw new Error("updateHex(hex) not supported for this alg:prov=" + this.algProvName);
     };
 
     /**
@@ -1119,7 +1119,7 @@ KJUR.crypto.Signature = function(params) {
      * var hSigValue = sig.sign()
      */
     this.sign = function() {
-	throw "sign() not supported for this alg:prov=" + this.algProvName;
+	throw new Error("sign() not supported for this alg:prov=" + this.algProvName);
     };
 
     /**
@@ -1134,7 +1134,7 @@ KJUR.crypto.Signature = function(params) {
      * var hSigValue = sig.signString('aaa')
      */
     this.signString = function(str) {
-	throw "digestString(str) not supported for this alg:prov=" + this.algProvName;
+	throw new Error("digestString(str) not supported for this alg:prov=" + this.algProvName);
     };
 
     /**
@@ -1149,7 +1149,7 @@ KJUR.crypto.Signature = function(params) {
      * var hSigValue = sig.signHex('1fdc33')
      */
     this.signHex = function(hex) {
-	throw "digestHex(hex) not supported for this alg:prov=" + this.algProvName;
+	throw new Error("digestHex(hex) not supported for this alg:prov=" + this.algProvName);
     };
 
     /**
@@ -1164,7 +1164,7 @@ KJUR.crypto.Signature = function(params) {
      * var isValid = sig.verify('1fbcefdca4823a7(snip)')
      */
     this.verify = function(hSigVal) {
-	throw "verify(hSigVal) not supported for this alg:prov=" + this.algProvName;
+	throw new Error("verify(hSigVal) not supported for this alg:prov=" + this.algProvName);
     };
 
     this.initParams = params;
@@ -1186,14 +1186,14 @@ KJUR.crypto.Signature = function(params) {
 
 	if (params['prvkeypem'] !== undefined) {
 	    if (params['prvkeypas'] !== undefined) {
-		throw "both prvkeypem and prvkeypas parameters not supported";
+		throw new Error("both prvkeypem and prvkeypas parameters not supported");
 	    } else {
 		try {
 		    var prvKey = new RSAKey();
 		    prvKey.readPrivateKeyFromPEMString(params['prvkeypem']);
 		    this.initSign(prvKey);
 		} catch (ex) {
-		    throw "fatal error to load pem private key: " + ex;
+		    throw new Error("fatal error to load pem private key: " + ex);
 		}
 	    }
 	}

--- a/dsa-modified-1.0.js
+++ b/dsa-modified-1.0.js
@@ -149,7 +149,7 @@ KJUR.crypto.DSA = function() {
 	    s1.compareTo(q) > 0 ||
 	    BigInteger.ZERO.compareTo(s2) > 0 ||
 	    s2.compareTo(q) > 0) {
-	    throw "invalid DSA signature";
+	    throw new Error("invalid DSA signature");
 	}
 	var w = s2.modInverse(q);
 	var u1 = hash.multiply(w).mod(q);
@@ -173,7 +173,7 @@ KJUR.crypto.DSA = function() {
 	    var s2 = new BigInteger(ASN1HEX.getVbyList(hSigVal, 0, [1], "02"), 16);
 	    return [s1, s2];
 	} catch (ex) {
-	    throw "malformed DSA signature";
+	    throw new Error("malformed DSA signature");
 	}
     }
 

--- a/ecdsa-modified-1.0.js
+++ b/ecdsa-modified-1.0.js
@@ -229,7 +229,7 @@ KJUR.crypto.ECDSA = function(params) {
 	    r = sig.r;
 	    s = sig.s;
 	} else {
-	    throw "Invalid value for signature";
+	    throw new Error("Invalid value for signature");
 	}
 
 	var Q;
@@ -238,7 +238,7 @@ KJUR.crypto.ECDSA = function(params) {
 	} else if (Bitcoin.Util.isArray(pubkey)) {
 	    Q = ECPointFp.decodeFrom(this.ecparams['curve'], pubkey);
 	} else {
-	    throw "Invalid format for pubkey value, must be byte array or ECPointFp";
+	    throw new Error("Invalid format for pubkey value, must be byte array or ECPointFp");
 	}
 	var e = BigInteger.fromByteArrayUnsigned(hash);
 
@@ -334,14 +334,14 @@ KJUR.crypto.ECDSA = function(params) {
 
     this.parseSigCompact = function (sig) {
 	if (sig.length !== 65) {
-	    throw "Signature has the wrong length";
+	    throw new Error("Signature has the wrong length");
 	}
 
 	// Signature is prefixed with a type byte storing three bits of
 	// information.
 	var i = sig[0] - 27;
 	if (i < 0 || i > 7) {
-	    throw "Invalid signature type";
+	    throw new Error("Invalid signature type");
 	}
 
 	var n = this.ecparams['n'];
@@ -412,7 +412,7 @@ KJUR.crypto.ECDSA = function(params) {
 
 	Q.validate();
 	if (!this.verifyRaw(e, r, s, Q)) {
-	    throw "Pubkey recovery unsuccessful";
+	    throw new Error("Pubkey recovery unsuccessful");
 	}
 
 	var pubKey = new Bitcoin.ECKey();
@@ -442,7 +442,7 @@ KJUR.crypto.ECDSA = function(params) {
 		}
 	    } catch (e) {}
 	}
-	throw "Unable to find valid recovery factor";
+	throw new Error("Unable to find valid recovery factor");
     }
     */
 
@@ -500,20 +500,20 @@ KJUR.crypto.ECDSA.parseSigHex = function(sigHex) {
 KJUR.crypto.ECDSA.parseSigHexInHexRS = function(sigHex) {
     // 1. ASN.1 Sequence Check
     if (sigHex.substr(0, 2) != "30")
-	throw "signature is not a ASN.1 sequence";
+	throw new Error("signature is not a ASN.1 sequence");
 
     // 2. Items of ASN.1 Sequence Check
     var a = ASN1HEX.getPosArrayOfChildren_AtObj(sigHex, 0);
     if (a.length != 2)
-	throw "number of signature ASN.1 sequence elements seem wrong";
+	throw new Error("number of signature ASN.1 sequence elements seem wrong");
     
     // 3. Integer check
     var iTLV1 = a[0];
     var iTLV2 = a[1];
     if (sigHex.substr(iTLV1, 2) != "02")
-	throw "1st item of sequene of signature is not ASN.1 integer";
+	throw new Error("1st item of sequene of signature is not ASN.1 integer");
     if (sigHex.substr(iTLV2, 2) != "02")
-	throw "2nd item of sequene of signature is not ASN.1 integer";
+	throw new Error("2nd item of sequene of signature is not ASN.1 integer");
 
     // 4. getting value
     var hR = ASN1HEX.getHexOfV_AtObj(sigHex, iTLV1);
@@ -544,10 +544,10 @@ KJUR.crypto.ECDSA.asn1SigToConcatSig = function(asn1Sig) {
 	hS = hS.substr(2);
 
     if ((((hR.length / 2) * 8) % (16 * 8)) != 0)
-	throw "unknown ECDSA sig r length error";
+	throw new Error("unknown ECDSA sig r length error");
 
     if ((((hS.length / 2) * 8) % (16 * 8)) != 0)
-	throw "unknown ECDSA sig s length error";
+	throw new Error("unknown ECDSA sig s length error");
 
     return hR + hS;
 };
@@ -564,7 +564,7 @@ KJUR.crypto.ECDSA.asn1SigToConcatSig = function(asn1Sig) {
  */
 KJUR.crypto.ECDSA.concatSigToASN1Sig = function(concatSig) {
     if ((((concatSig.length / 2) * 8) % (16 * 8)) != 0)
-	throw "unknown ECDSA concatinated r-s sig  length error";
+	throw new Error("unknown ECDSA concatinated r-s sig  length error");
 
     var hR = concatSig.substr(0, concatSig.length / 2);
     var hS = concatSig.substr(concatSig.length / 2);

--- a/ecparam-1.0.js
+++ b/ecparam-1.0.js
@@ -75,7 +75,7 @@ KJUR.crypto.ECParameterDB = new function() {
 	if (typeof db[name] != "undefined") {
 	    return db[name];
 	}
-	throw "unregistered EC curve name: " + name;
+	throw new Error("unregistered EC curve name: " + name);
     };
 
     /**

--- a/jws-3.3.js
+++ b/jws-3.3.js
@@ -135,7 +135,7 @@ KJUR.jws.JWS = function() {
 	    return;
 	}
 	if (sJWS.match(/^([^.]+)\.([^.]+)\.([^.]+)$/) == null) {
-	    throw "JWS signature is not a form of 'Head.Payload.SigValue'.";
+	    throw new Error("JWS signature is not a form of 'Head.Payload.SigValue'.");
 	}
 	var b6Head = RegExp.$1;
 	var b6Payload = RegExp.$2;
@@ -160,7 +160,7 @@ KJUR.jws.JWS = function() {
 	this.parsedJWS.payloadS = sPayload;
 
 	if (! ns1.isSafeJSONString(sHead, this.parsedJWS, 'headP'))
-	    throw "malformed JSON string for JWS Head: " + sHead;
+	    throw new Error("malformed JSON string for JWS Head: " + sHead);
     };
 };
 
@@ -238,7 +238,7 @@ KJUR.jws.JWS.sign = function(alg, spHeader, spPayload, key, pass) {
 
     // 1. check signatureInput(Header, Payload) is string or object
     if (typeof spHeader != 'string' && typeof spHeader != 'object')
-	throw "spHeader must be JSON string or object: " + spHeader;
+	throw new Error("spHeader must be JSON string or object: " + spHeader);
 
     if (typeof spHeader == 'object') {
 	pHeader = spHeader;
@@ -248,7 +248,7 @@ KJUR.jws.JWS.sign = function(alg, spHeader, spPayload, key, pass) {
     if (typeof spHeader == 'string') {
 	sHeader = spHeader;
 	if (! ns1.isSafeJSONString(sHeader))
-	    throw "JWS Head is not safe JSON string: " + sHeader;
+	    throw new Error("JWS Head is not safe JSON string: " + sHeader);
 	pHeader = ns1.readSafeJSONString(sHeader);
 
     }
@@ -271,12 +271,12 @@ KJUR.jws.JWS.sign = function(alg, spHeader, spPayload, key, pass) {
 
     // 4. check explicit algorithm doesn't match with JWS header.
     if (alg !== pHeader.alg)
-	throw "alg and sHeader.alg doesn't match: " + alg + "!=" + pHeader.alg;
+	throw new Error("alg and sHeader.alg doesn't match: " + alg + "!=" + pHeader.alg);
 
     // 5. set signature algorithm like SHA1withRSA
     var sigAlg = null;
     if (ns1.jwsalg2sigalg[alg] === undefined) {
-	throw "unsupported alg name: " + alg;
+	throw new Error("unsupported alg name: " + alg);
     } else {
 	sigAlg = ns1.jwsalg2sigalg[alg];
     }
@@ -288,7 +288,7 @@ KJUR.jws.JWS.sign = function(alg, spHeader, spPayload, key, pass) {
     var hSig = "";
     if (sigAlg.substr(0, 4) == "Hmac") {
 	if (key === undefined)
-	    throw "mac key shall be specified for HS* alg";
+	    throw new Error("mac key shall be specified for HS* alg");
 	//alert("sigAlg=" + sigAlg);
 	var mac = new KJUR.crypto.Mac({'alg': sigAlg, 'prov': 'cryptojs', 'pass': key});
 	mac.updateString(uSignatureInput);
@@ -391,7 +391,7 @@ KJUR.jws.JWS.verify = function(sJWS, key, acceptAlgs) {
     var alg = null;
     var algType = null; // HS|RS|PS|ES|no
     if (pHeader.alg === undefined) {
-	throw "algorithm not specified in header";
+	throw new Error("algorithm not specified in header");
     } else {
 	alg = pHeader.alg;
 	algType = alg.substr(0, 2);
@@ -403,13 +403,13 @@ KJUR.jws.JWS.verify = function(sJWS, key, acceptAlgs) {
         acceptAlgs.length > 0) {
 	var acceptAlgStr = ":" + acceptAlgs.join(":") + ":";
 	if (acceptAlgStr.indexOf(":" + alg + ":") == -1) {
-	    throw "algorithm '" + alg + "' not accepted in the list";
+	    throw new Error("algorithm '" + alg + "' not accepted in the list");
 	}
     }
 
     // 3. check whether key is a proper key for alg.
     if (alg != "none" && key === null) {
-	throw "key shall be specified to verify.";
+	throw new Error("key shall be specified to verify.");
     }
 
     // 3.1. There is no key check for HS* because Mac will check it.
@@ -424,14 +424,14 @@ KJUR.jws.JWS.verify = function(sJWS, key, acceptAlgs) {
     // 3.3. check whether key is RSAKey obj if alg is RS* or PS*.
     if (algType == "RS" || algType == "PS") {
 	if (!(key instanceof RSAKey)) {
-	    throw "key shall be a RSAKey obj for RS* and PS* algs";
+	    throw new Error("key shall be a RSAKey obj for RS* and PS* algs");
 	}
     }
 
     // 3.4. check whether key is ECDSA obj if alg is ES*.
     if (algType == "ES") {
 	if (!(key instanceof KJUR.crypto.ECDSA)) {
-	    throw "key shall be a ECDSA obj for ES* algs";
+	    throw new Error("key shall be a ECDSA obj for ES* algs");
 	}
     }
 
@@ -442,18 +442,18 @@ KJUR.jws.JWS.verify = function(sJWS, key, acceptAlgs) {
     // 4. check whether alg is supported alg in jsjws.
     var sigAlg = null;
     if (jws.jwsalg2sigalg[pHeader.alg] === undefined) {
-	throw "unsupported alg name: " + alg;
+	throw new Error("unsupported alg name: " + alg);
     } else {
 	sigAlg = jws.jwsalg2sigalg[alg];
     }
 
     // 5. verify
     if (sigAlg == "none") {
-        throw "not supported";
+        throw new Error("not supported");
     } else if (sigAlg.substr(0, 4) == "Hmac") {
 	var hSig2 = null;
 	if (key === undefined)
-	    throw "hexadecimal key shall be specified for HMAC";
+	    throw new Error("hexadecimal key shall be specified for HMAC");
 	//try {
 	    var mac = new KJUR.crypto.Mac({'alg': sigAlg, 'pass': key});
 	    mac.updateString(uSignatureInput);
@@ -522,7 +522,7 @@ KJUR.jws.JWS.parse = function(sJWS) {
     var result = {};
     var uHeader, uPayload, uSig;
     if (a.length != 2 && a.length != 3)
-	throw "malformed sJWS: wrong number of '.' splitted elements";
+	throw new Error("malformed sJWS: wrong number of '.' splitted elements");
 
     uHeader = a[0];
     uPayload = a[1];
@@ -650,7 +650,7 @@ KJUR.jws.JWS.verifyJWT = function(sJWT, key, acceptField) {
     // 4. algorithm ('alg' in header) check
     if (pHeader.alg === undefined) return false;
     if (acceptField.alg === undefined)
-	throw "acceptField.alg shall be specified";
+	throw new Error("acceptField.alg shall be specified");
     if (! ns1.inArray(pHeader.alg, acceptField.alg)) return false;
 
     // 5. issuer ('iss' in payload) check
@@ -850,7 +850,7 @@ KJUR.jws.JWS.readSafeJSONString = function(s) {
  */
 KJUR.jws.JWS.getEncodedSignatureValueFromJWS = function(sJWS) {
     if (sJWS.match(/^[^.]+\.[^.]+\.([^.]+)$/) == null) {
-	throw "JWS signature is not a form of 'Head.Payload.SigValue'.";
+	throw new Error("JWS signature is not a form of 'Head.Payload.SigValue'.");
     }
     return RegExp.$1;
 };
@@ -880,13 +880,13 @@ KJUR.jws.JWS.getJWKthumbprint = function(o) {
     if (o.kty !== "RSA" &&
 	o.kty !== "EC" &&
 	o.kty !== "oct")
-	throw "unsupported algorithm for JWK Thumprint";
+	throw new Error("unsupported algorithm for JWK Thumprint");
 
     // 1. get canonically ordered json string
     var s = '{';
     if (o.kty === "RSA") {
 	if (typeof o.n != "string" || typeof o.e != "string")
-	    throw "wrong n and e value for RSA key";
+	    throw new Error("wrong n and e value for RSA key");
 	s += '"' + 'e' + '":"' + o.e + '",';
 	s += '"' + 'kty' + '":"' + o.kty + '",';
 	s += '"' + 'n' + '":"' + o.n + '"}';
@@ -894,14 +894,14 @@ KJUR.jws.JWS.getJWKthumbprint = function(o) {
 	if (typeof o.crv != "string" || 
 	    typeof o.x != "string" ||
 	    typeof o.y != "string")
-	    throw "wrong crv, x and y value for EC key";
+	    throw new Error("wrong crv, x and y value for EC key");
 	s += '"' + 'crv' + '":"' + o.crv + '",';
 	s += '"' + 'kty' + '":"' + o.kty + '",';
 	s += '"' + 'x' + '":"' + o.x + '",';
 	s += '"' + 'y' + '":"' + o.y + '"}';
     } else if (o.kty === "oct") {
 	if (typeof o.k != "string")
-	    throw "wrong k value for oct(symmetric) key";
+	    throw new Error("wrong k value for oct(symmetric) key");
 	s += '"' + 'kty' + '":"' + o.kty + '",';
 	s += '"' + 'k' + '":"' + o.k + '"}';
     }
@@ -964,7 +964,7 @@ KJUR.jws.IntDate.get = function(s) {
     } else if (s.match(/^[0-9]+$/)) {
 	return parseInt(s);
     }
-    throw "unsupported format: " + s;
+    throw new Error("unsupported format: " + s);
 };
 
 /**
@@ -1001,10 +1001,10 @@ KJUR.jws.IntDate.getZulu = function(s) {
 	    } else if (0 <= year && year < 50) {
 		year = 2000 + year;
 	    } else {
-		throw "malformed year string for UTCTime";
+		throw new Error("malformed year string for UTCTime");
 	    }
 	} else {
-	    throw "malformed year string";
+	    throw new Error("malformed year string");
 	}
 	var month = parseInt(RegExp.$2) - 1;
 	var day = parseInt(RegExp.$3);
@@ -1014,7 +1014,7 @@ KJUR.jws.IntDate.getZulu = function(s) {
 	var d = new Date(Date.UTC(year, month, day, hour, min, sec));
 	return ~~(d / 1000);
     }
-    throw "unsupported format: " + s;
+    throw new Error("unsupported format: " + s);
 };
 
 /**

--- a/jwsjs-2.0.js
+++ b/jwsjs-2.0.js
@@ -128,9 +128,9 @@ KJUR.jws.JWSJS = function() {
      */
     this.verifyWithCerts = function(aCert) {
 		if (this.aHeader.length != aCert.length) 
-			throw "num headers does not match with num certs";
+			throw new Error("num headers does not match with num certs");
 		if (this.aSignature.length != aCert.length) 
-			throw "num signatures does not match with num certs";
+			throw new Error("num signatures does not match with num certs");
 
 		var payload = this.sPayload;
 		var errMsg = "";
@@ -168,7 +168,7 @@ KJUR.jws.JWSJS = function() {
      */
     this.readJWSJS = function(sJWSJS) {
 		var oJWSJS = ns1.readSafeJSONString(sJWSJS);
-		if (oJWSJS == null) throw "argument is not JSON string: " + sJWSJS;
+		if (oJWSJS == null) throw new Error("argument is not JSON string: " + sJWSJS);
 
 		this.aHeader = oJWSJS.headers;
 		this.sPayload = oJWSJS.payload;

--- a/keyutil-1.0.js
+++ b/keyutil-1.0.js
@@ -288,7 +288,7 @@ var KEYUTIL = function() {
         getHexFromPEM: function(sPEM, sHead) {
             var s = sPEM;
             if (s.indexOf("-----BEGIN ") == -1) {
-                throw "can't find PEM header: " + sHead;
+                throw new Error("can't find PEM header: " + sHead);
             }
             if (typeof sHead == "string" && sHead != "") {
                 s = s.replace("-----BEGIN " + sHead + "-----", "");
@@ -441,7 +441,7 @@ var KEYUTIL = function() {
                 sharedKeyAlgName = "AES-256-CBC";
             }
             if (typeof ALGLIST[sharedKeyAlgName] == "undefined")
-                throw "KEYUTIL unsupported algorithm: " + sharedKeyAlgName;
+                throw new Error("KEYUTIL unsupported algorithm: " + sharedKeyAlgName);
 
             // 2. set ivsaltHex if undefined
             if (typeof ivsaltHex == "undefined" || ivsaltHex == null) {
@@ -559,7 +559,7 @@ var KEYUTIL = function() {
          */
         getRSAKeyFromPlainPKCS8PEM: function(pkcs8PEM) {
             if (pkcs8PEM.match(/ENCRYPTED/))
-                throw "pem shall be not ENCRYPTED";
+                throw new Error("pem shall be not ENCRYPTED");
             var prvKeyHex = this.getHexFromPEM(pkcs8PEM, "PRIVATE KEY");
             var rsaKey = this.getRSAKeyFromPlainPKCS8Hex(prvKeyHex);
             return rsaKey;
@@ -578,10 +578,10 @@ var KEYUTIL = function() {
         getRSAKeyFromPlainPKCS8Hex: function(prvKeyHex) {
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(prvKeyHex, 0);
             if (a1.length != 3)
-                throw "outer DERSequence shall have 3 elements: " + a1.length;
+                throw new Error("outer DERSequence shall have 3 elements: " + a1.length);
             var algIdTLV =ASN1HEX.getHexOfTLV_AtObj(prvKeyHex, a1[1]);
             if (algIdTLV != "300d06092a864886f70d0101010500") // AlgId rsaEncryption
-                throw "PKCS8 AlgorithmIdentifier is not rsaEnc: " + algIdTLV;
+                throw new Error("PKCS8 AlgorithmIdentifier is not rsaEnc: " + algIdTLV);
             var algIdTLV = ASN1HEX.getHexOfTLV_AtObj(prvKeyHex, a1[1]);
             var octetStr = ASN1HEX.getHexOfTLV_AtObj(prvKeyHex, a1[2]);
             var p5KeyHex = ASN1HEX.getHexOfV_AtObj(octetStr, 0);
@@ -623,7 +623,7 @@ var KEYUTIL = function() {
             
             var a0 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, 0);
             if (a0.length != 2)
-                throw "malformed format: SEQUENCE(0).items != 2: " + a0.length;
+                throw new Error("malformed format: SEQUENCE(0).items != 2: " + a0.length);
 
             // 1. ciphertext
             info.ciphertext = ASN1HEX.getHexOfV_AtObj(sHEX, a0[1]);
@@ -631,23 +631,23 @@ var KEYUTIL = function() {
             // 2. pkcs5PBES2
             var a0_0 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0[0]); 
             if (a0_0.length != 2)
-                throw "malformed format: SEQUENCE(0.0).items != 2: " + a0_0.length;
+                throw new Error("malformed format: SEQUENCE(0.0).items != 2: " + a0_0.length);
 
             // 2.1 check if pkcs5PBES2(1 2 840 113549 1 5 13)
             if (ASN1HEX.getHexOfV_AtObj(sHEX, a0_0[0]) != "2a864886f70d01050d")
-                throw "this only supports pkcs5PBES2";
+                throw new Error("this only supports pkcs5PBES2");
 
             // 2.2 pkcs5PBES2 param
             var a0_0_1 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0_0[1]); 
             if (a0_0.length != 2)
-                throw "malformed format: SEQUENCE(0.0.1).items != 2: " + a0_0_1.length;
+                throw new Error("malformed format: SEQUENCE(0.0.1).items != 2: " + a0_0_1.length);
 
             // 2.2.1 encryptionScheme
             var a0_0_1_1 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0_0_1[1]); 
             if (a0_0_1_1.length != 2)
-                throw "malformed format: SEQUENCE(0.0.1.1).items != 2: " + a0_0_1_1.length;
+                throw new Error("malformed format: SEQUENCE(0.0.1.1).items != 2: " + a0_0_1_1.length);
             if (ASN1HEX.getHexOfV_AtObj(sHEX, a0_0_1_1[0]) != "2a864886f70d0307")
-                throw "this only supports TripleDES";
+                throw new Error("this only supports TripleDES");
             info.encryptionSchemeAlg = "TripleDES";
 
             // 2.2.1.1 IV of encryptionScheme
@@ -656,14 +656,14 @@ var KEYUTIL = function() {
             // 2.2.2 keyDerivationFunc
             var a0_0_1_0 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0_0_1[0]); 
             if (a0_0_1_0.length != 2)
-                throw "malformed format: SEQUENCE(0.0.1.0).items != 2: " + a0_0_1_0.length;
+                throw new Error("malformed format: SEQUENCE(0.0.1.0).items != 2: " + a0_0_1_0.length);
             if (ASN1HEX.getHexOfV_AtObj(sHEX, a0_0_1_0[0]) != "2a864886f70d01050c")
-                throw "this only supports pkcs5PBKDF2";
+                throw new Error("this only supports pkcs5PBKDF2");
 
             // 2.2.2.1 pkcs5PBKDF2 param
             var a0_0_1_0_1 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0_0_1_0[1]); 
             if (a0_0_1_0_1.length < 2)
-                throw "malformed format: SEQUENCE(0.0.1.0.1).items < 2: " + a0_0_1_0_1.length;
+                throw new Error("malformed format: SEQUENCE(0.0.1.0.1).items < 2: " + a0_0_1_0_1.length);
 
             // 2.2.2.1.1 PBKDF2 salt
             info.pbkdf2Salt = ASN1HEX.getHexOfV_AtObj(sHEX, a0_0_1_0_1[0]);
@@ -673,7 +673,7 @@ var KEYUTIL = function() {
             try {
                 info.pbkdf2Iter = parseInt(iterNumHex, 16);
             } catch(ex) {
-                throw "malformed format pbkdf2Iter: " + iterNumHex;
+                throw new Error("malformed format pbkdf2Iter: " + iterNumHex);
             }
 
             return info;
@@ -816,23 +816,23 @@ var KEYUTIL = function() {
 
             // 1. sequence
             if (pkcs8PrvHex.substr(0, 2) != "30")
-                throw "malformed plain PKCS8 private key(code:001)"; // not sequence
+                throw new Error("malformed plain PKCS8 private key(code:001)"); // not sequence
 
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PrvHex, 0);
             if (a1.length != 3)
-                throw "malformed plain PKCS8 private key(code:002)";
+                throw new Error("malformed plain PKCS8 private key(code:002)");
 
             // 2. AlgID
             if (pkcs8PrvHex.substr(a1[1], 2) != "30")
-                throw "malformed PKCS8 private key(code:003)"; // AlgId not sequence
+                throw new Error("malformed PKCS8 private key(code:003)"); // AlgId not sequence
 
             var a2 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PrvHex, a1[1]);
             if (a2.length != 2)
-                throw "malformed PKCS8 private key(code:004)"; // AlgId not have two elements
+                throw new Error("malformed PKCS8 private key(code:004)"); // AlgId not have two elements
 
             // 2.1. AlgID OID
             if (pkcs8PrvHex.substr(a2[0], 2) != "06")
-                throw "malformed PKCS8 private key(code:005)"; // AlgId.oid is not OID
+                throw new Error("malformed PKCS8 private key(code:005)"); // AlgId.oid is not OID
 
             result.algoid = ASN1HEX.getHexOfV_AtObj(pkcs8PrvHex, a2[0]);
 
@@ -843,7 +843,7 @@ var KEYUTIL = function() {
 
             // 3. Key index
             if (pkcs8PrvHex.substr(a1[2], 2) != "04")
-                throw "malformed PKCS8 private key(code:006)"; // not octet string
+                throw new Error("malformed PKCS8 private key(code:006)"); // not octet string
 
             result.keyidx = ASN1HEX.getStartPosOfV_AtObj(pkcs8PrvHex, a1[2]);
 
@@ -886,7 +886,7 @@ var KEYUTIL = function() {
             } else if (p8.algoid == "2a8648ce3d0201") { // ECC
                 this.parsePrivateRawECKeyHexAtObj(prvKeyHex, p8);
                 if (KJUR.crypto.OID.oidhex2name[p8.algparam] === undefined)
-                    throw "KJUR.crypto.OID.oidhex2name undefined: " + p8.algparam;
+                    throw new Error("KJUR.crypto.OID.oidhex2name undefined: " + p8.algparam);
                 var curveName = KJUR.crypto.OID.oidhex2name[p8.algparam];
                 var key = new KJUR.crypto.ECDSA({'curve': curveName});
                 key.setPublicKeyHex(p8.pubkey);
@@ -906,7 +906,7 @@ var KEYUTIL = function() {
                 key.setPrivate(biP, biQ, biG, null, biX);
                 return key;
             } else {
-                throw "unsupported private key algorithm";
+                throw new Error("unsupported private key algorithm");
             }
         },
 
@@ -963,7 +963,7 @@ var KEYUTIL = function() {
                 return key;
             } else if (p8.algoid == "2a8648ce3d0201") { // ECC
                 if (KJUR.crypto.OID.oidhex2name[p8.algparam] === undefined)
-                    throw "KJUR.crypto.OID.oidhex2name undefined: " + p8.algparam;
+                    throw new Error("KJUR.crypto.OID.oidhex2name undefined: " + p8.algparam);
                 var curveName = KJUR.crypto.OID.oidhex2name[p8.algparam];
                 var key = new KJUR.crypto.ECDSA({'curve': curveName, 'pub': p8.key});
                 return key;
@@ -977,7 +977,7 @@ var KEYUTIL = function() {
                               new BigInteger(y, 16));
                 return key;
             } else {
-                throw "unsupported public key algorithm";
+                throw new Error("unsupported public key algorithm");
             }
         },
 
@@ -1001,21 +1001,21 @@ var KEYUTIL = function() {
             
             // 1. Sequence
             if (pubRawRSAHex.substr(0, 2) != "30")
-                throw "malformed RSA key(code:001)"; // not sequence
+                throw new Error("malformed RSA key(code:001)"); // not sequence
             
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(pubRawRSAHex, 0);
             if (a1.length != 2)
-                throw "malformed RSA key(code:002)"; // not 2 items in seq
+                throw new Error("malformed RSA key(code:002)"); // not 2 items in seq
 
             // 2. public key "N"
             if (pubRawRSAHex.substr(a1[0], 2) != "02")
-                throw "malformed RSA key(code:003)"; // 1st item is not integer
+                throw new Error("malformed RSA key(code:003)"); // 1st item is not integer
 
             result.n = ASN1HEX.getHexOfV_AtObj(pubRawRSAHex, a1[0]);
 
             // 3. public key "E"
             if (pubRawRSAHex.substr(a1[1], 2) != "02")
-                throw "malformed RSA key(code:004)"; // 2nd item is not integer
+                throw new Error("malformed RSA key(code:004)"); // 2nd item is not integer
 
             result.e = ASN1HEX.getHexOfV_AtObj(pubRawRSAHex, a1[1]);
 
@@ -1048,11 +1048,11 @@ var KEYUTIL = function() {
             
             // 1. sequence
             if (pkcs8PrvHex.substr(keyIdx, 2) != "30")
-                throw "malformed RSA private key(code:001)"; // not sequence
+                throw new Error("malformed RSA private key(code:001)"); // not sequence
 
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PrvHex, keyIdx);
             if (a1.length != 9)
-                throw "malformed RSA private key(code:002)"; // not sequence
+                throw new Error("malformed RSA private key(code:002)"); // not sequence
 
             // 2. RSA key
             info.key = {};
@@ -1112,20 +1112,20 @@ var KEYUTIL = function() {
             // 1. AlgID and Key bit string
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PubHex, 0);
             if (a1.length != 2)
-                throw "outer DERSequence shall have 2 elements: " + a1.length;
+                throw new Error("outer DERSequence shall have 2 elements: " + a1.length);
 
             // 2. AlgID
             var idxAlgIdTLV = a1[0];
             if (pkcs8PubHex.substr(idxAlgIdTLV, 2) != "30")
-                throw "malformed PKCS8 public key(code:001)"; // AlgId not sequence
+                throw new Error("malformed PKCS8 public key(code:001)"); // AlgId not sequence
 
             var a2 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PubHex, idxAlgIdTLV);
             if (a2.length != 2)
-                throw "malformed PKCS8 public key(code:002)"; // AlgId not have two elements
+                throw new Error("malformed PKCS8 public key(code:002)"); // AlgId not have two elements
 
             // 2.1. AlgID OID
             if (pkcs8PubHex.substr(a2[0], 2) != "06")
-                throw "malformed PKCS8 public key(code:003)"; // AlgId.oid is not OID
+                throw new Error("malformed PKCS8 public key(code:003)"); // AlgId.oid is not OID
 
             result.algoid = ASN1HEX.getHexOfV_AtObj(pkcs8PubHex, a2[0]);
 
@@ -1141,7 +1141,7 @@ var KEYUTIL = function() {
 
             // 3. Key
             if (pkcs8PubHex.substr(a1[1], 2) != "03")
-                throw "malformed PKCS8 public key(code:004)"; // Key is not bit string
+                throw new Error("malformed PKCS8 public key(code:004)"); // Key is not bit string
 
             result.key = ASN1HEX.getHexOfV_AtObj(pkcs8PubHex, a1[1]).substr(2);
             
@@ -1162,28 +1162,28 @@ var KEYUTIL = function() {
         getRSAKeyFromPublicPKCS8Hex: function(pkcs8PubHex) {
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PubHex, 0);
             if (a1.length != 2)
-                throw "outer DERSequence shall have 2 elements: " + a1.length;
+                throw new Error("outer DERSequence shall have 2 elements: " + a1.length);
 
             var algIdTLV =ASN1HEX.getHexOfTLV_AtObj(pkcs8PubHex, a1[0]);
             if (algIdTLV != "300d06092a864886f70d0101010500") // AlgId rsaEncryption
-                throw "PKCS8 AlgorithmId is not rsaEncryption";
+                throw new Error("PKCS8 AlgorithmId is not rsaEncryption");
             
             if (pkcs8PubHex.substr(a1[1], 2) != "03")
-                throw "PKCS8 Public Key is not BITSTRING encapslated.";
+                throw new Error("PKCS8 Public Key is not BITSTRING encapslated.");
 
             var idxPub = ASN1HEX.getStartPosOfV_AtObj(pkcs8PubHex, a1[1]) + 2; // 2 for unused bit
             
             if (pkcs8PubHex.substr(idxPub, 2) != "30")
-                throw "PKCS8 Public Key is not SEQUENCE.";
+                throw new Error("PKCS8 Public Key is not SEQUENCE.");
 
             var a2 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PubHex, idxPub);
             if (a2.length != 2)
-                throw "inner DERSequence shall have 2 elements: " + a2.length;
+                throw new Error("inner DERSequence shall have 2 elements: " + a2.length);
 
             if (pkcs8PubHex.substr(a2[0], 2) != "02") 
-                throw "N is not ASN.1 INTEGER";
+                throw new Error("N is not ASN.1 INTEGER");
             if (pkcs8PubHex.substr(a2[1], 2) != "02") 
-                throw "E is not ASN.1 INTEGER";
+                throw new Error("E is not ASN.1 INTEGER");
             
             var hN = ASN1HEX.getHexOfV_AtObj(pkcs8PubHex, a2[0]);
             var hE = ASN1HEX.getHexOfV_AtObj(pkcs8PubHex, a2[1]);
@@ -1509,7 +1509,7 @@ KEYUTIL.getKey = function(param, passcode, hextype) {
         if (KJUR.crypto.OID.oidhex2name[curveNameOidHex] !== undefined) {
             curveName = KJUR.crypto.OID.oidhex2name[curveNameOidHex];
         } else {
-            throw "undefined OID(hex) in KJUR.crypto.OID: " + curveNameOidHex;
+            throw new Error("undefined OID(hex) in KJUR.crypto.OID: " + curveNameOidHex);
         }
 
         var ec = new KJUR.crypto.ECDSA({'name': curveName});
@@ -1542,7 +1542,7 @@ KEYUTIL.getKey = function(param, passcode, hextype) {
         return KEYUTIL.getKeyFromEncryptedPKCS8PEM(param, passcode);
     }
 
-    throw "not supported argument";
+    throw new Error("not supported argument");
 };
 
 /**
@@ -1611,7 +1611,7 @@ KEYUTIL.generateKeypair = function(alg, keylenOrCurve) {
         result.pubKeyObj = pubKey;
         return result;
     } else {
-        throw "unknown algorithm: " + alg;
+        throw new Error("unknown algorithm: " + alg);
     }
 };
 
@@ -1945,7 +1945,7 @@ KEYUTIL.getPEM = function(keyObjOrHex, formatType, passwd, encAlg, hexType) {
         }
     }
 
-    throw "unsupported object nor format";
+    throw new Error("unsupported object nor format");
 };
 
 // -- PUBLIC METHODS FOR CSR -------------------------------------------------------
@@ -2000,19 +2000,19 @@ KEYUTIL.parseCSRHex = function(csrHex) {
 
     // 1. sequence
     if (h.substr(0, 2) != "30")
-        throw "malformed CSR(code:001)"; // not sequence
+        throw new Error("malformed CSR(code:001)"); // not sequence
 
     var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(h, 0);
     if (a1.length < 1)
-        throw "malformed CSR(code:002)"; // short length
+        throw new Error("malformed CSR(code:002)"); // short length
 
     // 2. 2nd sequence
     if (h.substr(a1[0], 2) != "30")
-        throw "malformed CSR(code:003)"; // not sequence
+        throw new Error("malformed CSR(code:003)"); // not sequence
 
     var a2 = ASN1HEX.getPosArrayOfChildren_AtObj(h, a1[0]);
     if (a2.length < 3)
-        throw "malformed CSR(code:004)"; // 2nd seq short elem
+        throw new Error("malformed CSR(code:004)"); // 2nd seq short elem
 
     result.p8pubkeyhex = ASN1HEX.getHexOfTLV_AtObj(h, a2[2]);
 

--- a/pkcs5pkey-1.0.js
+++ b/pkcs5pkey-1.0.js
@@ -262,7 +262,7 @@ var PKCS5PKEY = function() {
         getHexFromPEM: function(sPEM, sHead) {
             var s = sPEM;
             if (s.indexOf("BEGIN " + sHead) == -1) {
-                throw "can't find PEM header: " + sHead;
+                throw new Error("can't find PEM header: " + sHead);
             }
             s = s.replace("-----BEGIN " + sHead + "-----", "");
             s = s.replace("-----END " + sHead + "-----", "");
@@ -407,7 +407,7 @@ var PKCS5PKEY = function() {
                 sharedKeyAlgName = "AES-256-CBC";
             }
             if (typeof ALGLIST[sharedKeyAlgName] == "undefined")
-                throw "PKCS5PKEY unsupported algorithm: " + sharedKeyAlgName;
+                throw new Error("PKCS5PKEY unsupported algorithm: " + sharedKeyAlgName);
 
             // 2. set ivsaltHex if undefined
             if (typeof ivsaltHex == "undefined" || ivsaltHex == null) {
@@ -523,7 +523,7 @@ var PKCS5PKEY = function() {
          */
         getRSAKeyFromPlainPKCS8PEM: function(pkcs8PEM) {
             if (pkcs8PEM.match(/ENCRYPTED/))
-                throw "pem shall be not ENCRYPTED";
+                throw new Error("pem shall be not ENCRYPTED");
             var prvKeyHex = this.getHexFromPEM(pkcs8PEM, "PRIVATE KEY");
             var rsaKey = this.getRSAKeyFromPlainPKCS8Hex(prvKeyHex);
             return rsaKey;
@@ -541,10 +541,10 @@ var PKCS5PKEY = function() {
         getRSAKeyFromPlainPKCS8Hex: function(prvKeyHex) {
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(prvKeyHex, 0);
             if (a1.length != 3)
-                throw "outer DERSequence shall have 3 elements: " + a1.length;
+                throw new Error("outer DERSequence shall have 3 elements: " + a1.length);
             var algIdTLV =ASN1HEX.getHexOfTLV_AtObj(prvKeyHex, a1[1]);
             if (algIdTLV != "300d06092a864886f70d0101010500") // AlgId rsaEncryption
-                throw "PKCS8 AlgorithmIdentifier is not rsaEnc: " + algIdTLV;
+                throw new Error("PKCS8 AlgorithmIdentifier is not rsaEnc: " + algIdTLV);
             var algIdTLV = ASN1HEX.getHexOfTLV_AtObj(prvKeyHex, a1[1]);
             var octetStr = ASN1HEX.getHexOfTLV_AtObj(prvKeyHex, a1[2]);
             var p5KeyHex = ASN1HEX.getHexOfV_AtObj(octetStr, 0);
@@ -586,7 +586,7 @@ var PKCS5PKEY = function() {
         
             var a0 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, 0);
             if (a0.length != 2)
-                throw "malformed format: SEQUENCE(0).items != 2: " + a0.length;
+                throw new Error("malformed format: SEQUENCE(0).items != 2: " + a0.length);
 
             // 1. ciphertext
             info.ciphertext = ASN1HEX.getHexOfV_AtObj(sHEX, a0[1]);
@@ -594,23 +594,23 @@ var PKCS5PKEY = function() {
             // 2. pkcs5PBES2
             var a0_0 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0[0]); 
             if (a0_0.length != 2)
-                throw "malformed format: SEQUENCE(0.0).items != 2: " + a0_0.length;
+                throw new Error("malformed format: SEQUENCE(0.0).items != 2: " + a0_0.length);
 
             // 2.1 check if pkcs5PBES2(1 2 840 113549 1 5 13)
             if (ASN1HEX.getHexOfV_AtObj(sHEX, a0_0[0]) != "2a864886f70d01050d")
-                throw "this only supports pkcs5PBES2";
+                throw new Error("this only supports pkcs5PBES2");
 
             // 2.2 pkcs5PBES2 param
             var a0_0_1 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0_0[1]); 
             if (a0_0.length != 2)
-                throw "malformed format: SEQUENCE(0.0.1).items != 2: " + a0_0_1.length;
+                throw new Error("malformed format: SEQUENCE(0.0.1).items != 2: " + a0_0_1.length);
 
             // 2.2.1 encryptionScheme
             var a0_0_1_1 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0_0_1[1]); 
             if (a0_0_1_1.length != 2)
-                throw "malformed format: SEQUENCE(0.0.1.1).items != 2: " + a0_0_1_1.length;
+                throw new Error("malformed format: SEQUENCE(0.0.1.1).items != 2: " + a0_0_1_1.length);
             if (ASN1HEX.getHexOfV_AtObj(sHEX, a0_0_1_1[0]) != "2a864886f70d0307")
-                throw "this only supports TripleDES";
+                throw new Error("this only supports TripleDES");
             info.encryptionSchemeAlg = "TripleDES";
 
             // 2.2.1.1 IV of encryptionScheme
@@ -619,14 +619,14 @@ var PKCS5PKEY = function() {
             // 2.2.2 keyDerivationFunc
             var a0_0_1_0 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0_0_1[0]); 
             if (a0_0_1_0.length != 2)
-                throw "malformed format: SEQUENCE(0.0.1.0).items != 2: " + a0_0_1_0.length;
+                throw new Error("malformed format: SEQUENCE(0.0.1.0).items != 2: " + a0_0_1_0.length);
             if (ASN1HEX.getHexOfV_AtObj(sHEX, a0_0_1_0[0]) != "2a864886f70d01050c")
-                throw "this only supports pkcs5PBKDF2";
+                throw new Error("this only supports pkcs5PBKDF2");
             
             // 2.2.2.1 pkcs5PBKDF2 param
             var a0_0_1_0_1 = ASN1HEX.getPosArrayOfChildren_AtObj(sHEX, a0_0_1_0[1]); 
             if (a0_0_1_0_1.length < 2)
-                throw "malformed format: SEQUENCE(0.0.1.0.1).items < 2: " + a0_0_1_0_1.length;
+                throw new Error("malformed format: SEQUENCE(0.0.1.0.1).items < 2: " + a0_0_1_0_1.length);
 
             // 2.2.2.1.1 PBKDF2 salt
             info.pbkdf2Salt = ASN1HEX.getHexOfV_AtObj(sHEX, a0_0_1_0_1[0]);
@@ -636,7 +636,7 @@ var PKCS5PKEY = function() {
             try {
                 info.pbkdf2Iter = parseInt(iterNumHex, 16);
             } catch(ex) {
-                throw "malformed format pbkdf2Iter: " + iterNumHex;
+                throw new Error("malformed format pbkdf2Iter: " + iterNumHex);
             }
 
             return info;
@@ -778,23 +778,23 @@ var PKCS5PKEY = function() {
 
             // 1. sequence
             if (pkcs8PrvHex.substr(0, 2) != "30")
-                throw "malformed plain PKCS8 private key(code:001)"; // not sequence
+                throw new Error("malformed plain PKCS8 private key(code:001)"); // not sequence
 
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PrvHex, 0);
             if (a1.length != 3)
-                throw "malformed plain PKCS8 private key(code:002)";
+                throw new Error("malformed plain PKCS8 private key(code:002)");
 
             // 2. AlgID
             if (pkcs8PrvHex.substr(a1[1], 2) != "30")
-                throw "malformed PKCS8 private key(code:003)"; // AlgId not sequence
+                throw new Error("malformed PKCS8 private key(code:003)"); // AlgId not sequence
 
             var a2 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PrvHex, a1[1]);
             if (a2.length != 2)
-                throw "malformed PKCS8 private key(code:004)"; // AlgId not have two elements
+                throw new Error("malformed PKCS8 private key(code:004)"); // AlgId not have two elements
 
             // 2.1. AlgID OID
             if (pkcs8PrvHex.substr(a2[0], 2) != "06")
-                throw "malformed PKCS8 private key(code:005)"; // AlgId.oid is not OID
+                throw new Error("malformed PKCS8 private key(code:005)"); // AlgId.oid is not OID
 
             result.algoid = ASN1HEX.getHexOfV_AtObj(pkcs8PrvHex, a2[0]);
 
@@ -805,7 +805,7 @@ var PKCS5PKEY = function() {
 
             // 3. Key index
             if (pkcs8PrvHex.substr(a1[2], 2) != "04")
-                throw "malformed PKCS8 private key(code:006)"; // not octet string
+                throw new Error("malformed PKCS8 private key(code:006)"); // not octet string
 
             result.keyidx = ASN1HEX.getStartPosOfV_AtObj(pkcs8PrvHex, a1[2]);
 
@@ -848,12 +848,12 @@ var PKCS5PKEY = function() {
             } else if (p8.algoid == "2a8648ce3d0201") { // ECC
                 this.parsePrivateRawECKeyHexAtObj(prvKeyHex, p8);
                 if (KJUR.crypto.OID.oidhex2name[p8.algparam] === undefined)
-                    throw "KJUR.crypto.OID.oidhex2name undefined: " + p8.algparam;
+                    throw new Error("KJUR.crypto.OID.oidhex2name undefined: " + p8.algparam);
                 var curveName = KJUR.crypto.OID.oidhex2name[p8.algparam];
                 var key = new KJUR.crypto.ECDSA({'curve': curveName, 'prv': p8.key});
                 return key;
             } else {
-                throw "unsupported private key algorithm";
+                throw new Error("unsupported private key algorithm");
             }
         },
 
@@ -907,12 +907,12 @@ var PKCS5PKEY = function() {
                 return key;
             } else if (p8.algoid == "2a8648ce3d0201") { // ECC
                 if (KJUR.crypto.OID.oidhex2name[p8.algparam] === undefined)
-                    throw "KJUR.crypto.OID.oidhex2name undefined: " + p8.algparam;
+                    throw new Error("KJUR.crypto.OID.oidhex2name undefined: " + p8.algparam);
                 var curveName = KJUR.crypto.OID.oidhex2name[p8.algparam];
                 var key = new KJUR.crypto.ECDSA({'curve': curveName, 'pub': p8.key});
                 return key;
             } else {
-                throw "unsupported public key algorithm";
+                throw new Error("unsupported public key algorithm");
             }
         },
 
@@ -936,21 +936,21 @@ var PKCS5PKEY = function() {
             
             // 1. Sequence
             if (pubRawRSAHex.substr(0, 2) != "30")
-                throw "malformed RSA key(code:001)"; // not sequence
+                throw new Error("malformed RSA key(code:001)"); // not sequence
             
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(pubRawRSAHex, 0);
             if (a1.length != 2)
-                throw "malformed RSA key(code:002)"; // not 2 items in seq
+                throw new Error("malformed RSA key(code:002)"); // not 2 items in seq
 
             // 2. public key "N"
             if (pubRawRSAHex.substr(a1[0], 2) != "02")
-                throw "malformed RSA key(code:003)"; // 1st item is not integer
+                throw new Error("malformed RSA key(code:003)"); // 1st item is not integer
 
             result.n = ASN1HEX.getHexOfV_AtObj(pubRawRSAHex, a1[0]);
 
             // 3. public key "E"
             if (pubRawRSAHex.substr(a1[1], 2) != "02")
-                throw "malformed RSA key(code:004)"; // 2nd item is not integer
+                throw new Error("malformed RSA key(code:004)"); // 2nd item is not integer
 
             result.e = ASN1HEX.getHexOfV_AtObj(pubRawRSAHex, a1[1]);
 
@@ -983,11 +983,11 @@ var PKCS5PKEY = function() {
             
             // 1. sequence
             if (pkcs8PrvHex.substr(keyIdx, 2) != "30")
-                throw "malformed RSA private key(code:001)"; // not sequence
+                throw new Error("malformed RSA private key(code:001)"); // not sequence
 
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PrvHex, keyIdx);
             if (a1.length != 9)
-                throw "malformed RSA private key(code:002)"; // not sequence
+                throw new Error("malformed RSA private key(code:002)"); // not sequence
 
             // 2. RSA key
             info.key = {};
@@ -1020,15 +1020,15 @@ var PKCS5PKEY = function() {
             
             // 1. sequence
             if (pkcs8PrvHex.substr(keyIdx, 2) != "30")
-                throw "malformed ECC private key(code:001)"; // not sequence
+                throw new Error("malformed ECC private key(code:001)"); // not sequence
 
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PrvHex, keyIdx);
             if (a1.length != 3)
-                throw "malformed ECC private key(code:002)"; // not sequence
+                throw new Error("malformed ECC private key(code:002)"); // not sequence
 
             // 2. EC private key
             if (pkcs8PrvHex.substr(a1[1], 2) != "04")
-                throw "malformed ECC private key(code:003)"; // not octetstring
+                throw new Error("malformed ECC private key(code:003)"); // not octetstring
 
             info.key = ASN1HEX.getHexOfV_AtObj(pkcs8PrvHex, a1[1]);
         },
@@ -1055,20 +1055,20 @@ var PKCS5PKEY = function() {
             // 1. AlgID and Key bit string
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PubHex, 0);
             if (a1.length != 2)
-                throw "outer DERSequence shall have 2 elements: " + a1.length;
+                throw new Error("outer DERSequence shall have 2 elements: " + a1.length);
 
             // 2. AlgID
             var idxAlgIdTLV = a1[0];
             if (pkcs8PubHex.substr(idxAlgIdTLV, 2) != "30")
-                throw "malformed PKCS8 public key(code:001)"; // AlgId not sequence
+                throw new Error("malformed PKCS8 public key(code:001)"); // AlgId not sequence
 
             var a2 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PubHex, idxAlgIdTLV);
             if (a2.length != 2)
-                throw "malformed PKCS8 public key(code:002)"; // AlgId not have two elements
+                throw new Error("malformed PKCS8 public key(code:002)"); // AlgId not have two elements
 
             // 2.1. AlgID OID
             if (pkcs8PubHex.substr(a2[0], 2) != "06")
-                throw "malformed PKCS8 public key(code:003)"; // AlgId.oid is not OID
+                throw new Error("malformed PKCS8 public key(code:003)"); // AlgId.oid is not OID
 
             result.algoid = ASN1HEX.getHexOfV_AtObj(pkcs8PubHex, a2[0]);
 
@@ -1079,7 +1079,7 @@ var PKCS5PKEY = function() {
 
             // 3. Key
             if (pkcs8PubHex.substr(a1[1], 2) != "03")
-                throw "malformed PKCS8 public key(code:004)"; // Key is not bit string
+                throw new Error("malformed PKCS8 public key(code:004)"); // Key is not bit string
 
             result.key = ASN1HEX.getHexOfV_AtObj(pkcs8PubHex, a1[1]).substr(2);
             
@@ -1099,28 +1099,28 @@ var PKCS5PKEY = function() {
         getRSAKeyFromPublicPKCS8Hex: function(pkcs8PubHex) {
             var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PubHex, 0);
             if (a1.length != 2)
-                throw "outer DERSequence shall have 2 elements: " + a1.length;
+                throw new Error("outer DERSequence shall have 2 elements: " + a1.length);
 
             var algIdTLV =ASN1HEX.getHexOfTLV_AtObj(pkcs8PubHex, a1[0]);
             if (algIdTLV != "300d06092a864886f70d0101010500") // AlgId rsaEncryption
-                throw "PKCS8 AlgorithmId is not rsaEncryption";
+                throw new Error("PKCS8 AlgorithmId is not rsaEncryption");
             
             if (pkcs8PubHex.substr(a1[1], 2) != "03")
-                throw "PKCS8 Public Key is not BITSTRING encapslated.";
+                throw new Error("PKCS8 Public Key is not BITSTRING encapslated.");
 
             var idxPub = ASN1HEX.getStartPosOfV_AtObj(pkcs8PubHex, a1[1]) + 2; // 2 for unused bit
             
             if (pkcs8PubHex.substr(idxPub, 2) != "30")
-                throw "PKCS8 Public Key is not SEQUENCE.";
+                throw new Error("PKCS8 Public Key is not SEQUENCE.");
 
             var a2 = ASN1HEX.getPosArrayOfChildren_AtObj(pkcs8PubHex, idxPub);
             if (a2.length != 2)
-                throw "inner DERSequence shall have 2 elements: " + a2.length;
+                throw new Error("inner DERSequence shall have 2 elements: " + a2.length);
 
             if (pkcs8PubHex.substr(a2[0], 2) != "02") 
-                throw "N is not ASN.1 INTEGER";
+                throw new Error("N is not ASN.1 INTEGER");
             if (pkcs8PubHex.substr(a2[1], 2) != "02") 
-                throw "E is not ASN.1 INTEGER";
+                throw new Error("E is not ASN.1 INTEGER");
             
             var hN = ASN1HEX.getHexOfV_AtObj(pkcs8PubHex, a2[0]);
             var hE = ASN1HEX.getHexOfV_AtObj(pkcs8PubHex, a2[1]);

--- a/rsasign-1.2.js
+++ b/rsasign-1.2.js
@@ -159,11 +159,11 @@ function _rsasign_signWithMessageHashPSS(hHash, hashAlg, sLen) {
     } else if (sLen === -2) {
         sLen = emLen - hLen - 2; // maximum
     } else if (sLen < -2) {
-        throw "invalid salt length";
+        throw new Error("invalid salt length");
     }
 
     if (emLen < (hLen + sLen + 2)) {
-        throw "data too long";
+        throw new Error("data too long");
     }
 
     var salt = '';
@@ -367,11 +367,11 @@ function _rsasign_verifyWithMessageHashPSS(hHash, hSig, hashAlg, sLen) {
     } else if (sLen === -2) {
         sLen = emLen - hLen - 2; // recover
     } else if (sLen < -2) {
-        throw "invalid salt length";
+        throw new Error("invalid salt length");
     }
 
     if (emLen < (hLen + sLen + 2)) {
-        throw "data too long";
+        throw new Error("data too long");
     }
 
     var em = this.doPublic(biSig).toByteArray();
@@ -385,7 +385,7 @@ function _rsasign_verifyWithMessageHashPSS(hHash, hSig, hashAlg, sLen) {
     }
 
     if (em[emLen -1] !== 0xbc) {
-        throw "encoded message does not end in 0xbc";
+        throw new Error("encoded message does not end in 0xbc");
     }
 
     em = String.fromCharCode.apply(String, em);
@@ -396,7 +396,7 @@ function _rsasign_verifyWithMessageHashPSS(hHash, hSig, hashAlg, sLen) {
     var mask = (0xff00 >> (8 * emLen - emBits)) & 0xff;
 
     if ((maskedDB.charCodeAt(0) & mask) !== 0) {
-        throw "bits beyond keysize not zero";
+        throw new Error("bits beyond keysize not zero");
     }
 
     var dbMask = pss_mgf1_str(H, maskedDB.length, hashFunc);
@@ -412,12 +412,12 @@ function _rsasign_verifyWithMessageHashPSS(hHash, hSig, hashAlg, sLen) {
 
     for (i = 0; i < checkLen; i += 1) {
         if (DB[i] !== 0x00) {
-            throw "leftmost octets not zero";
+            throw new Error("leftmost octets not zero");
         }
     }
 
     if (DB[checkLen] !== 0x01) {
-        throw "0x01 marker not found";
+        throw new Error("0x01 marker not found");
     }
 
     return H === hextorstr(hashFunc(rstrtohex('\x00\x00\x00\x00\x00\x00\x00\x00' + mHash +

--- a/sample_node/asn1dump
+++ b/sample_node/asn1dump
@@ -24,7 +24,7 @@ program
   .parse(process.argv);
 
 if (program.args.length !== 1)
-  throw "wrong number of arguments";
+  throw new Error("wrong number of arguments");
 
 var file = program.args[0];
 

--- a/sample_node/asn1extract
+++ b/sample_node/asn1extract
@@ -27,7 +27,7 @@ program
   .parse(process.argv);
 
 if (program.args.length < 3)
-  throw "wrong number of arguments";
+  throw new Error("wrong number of arguments");
 
 var outFile = program.args[0];
 var inFile = program.args[1];
@@ -36,7 +36,7 @@ var hex;
 try {
   hex = rs.readFileHexByBin(inFile);
 } catch(ex) {
-  throw "can't read file: " + inFile;
+  throw new Error("can't read file: " + inFile);
 }
 
 var idxList = program.args.slice(2);

--- a/sample_node/gencsr
+++ b/sample_node/gencsr
@@ -48,7 +48,7 @@ program
 //console.log("program.args.length=" + program.args.length);
 
 if (program.args.length !== 1)
-  throw "wrong number of args"
+  throw new Error("wrong number of args");
 
 var head = program.args[0];
 var dn = program.dn;

--- a/sample_node/jwssign
+++ b/sample_node/jwssign
@@ -30,7 +30,7 @@ program
   .parse(process.argv);
 
 if (program.args.length !== 3)
-  throw "wrong number of arguments";
+  throw new Error("wrong number of arguments");
 var outFile = program.args[2];
 
 var sHeader, pHeader, sPayload;
@@ -56,7 +56,7 @@ try {
 
 pHeader = JWS.readSafeJSONString(sHeader);
 if (pHeader === null)
-  throw "error: not safe JSON header: " + sHeader;
+  throw new Error("error: not safe JSON header: " + sHeader);
 
 /*
  * pass, prvkey and sigalg check
@@ -68,7 +68,7 @@ if (program.forcealg !== undefined && pHeader.alg !== program.forcealg) {
 
 pass = {};
 if (! JWS.inArray(program.passtype, ['utf8', 'hex', 'b64', 'b64u']))
-  throw "unsupported HS* password type: " + program.passtype;
+  throw new Error("unsupported HS* password type: " + program.passtype);
 if (program.passtype !== undefined && program.pass !== undefined)
   pass[program.passtype] = program.pass;
 
@@ -78,15 +78,15 @@ if (program.prvkey !== undefined) {
 }
 
 if (prvKeyObj === undefined && ! pHeader.alg.match(/^HS/))
-  throw "sigalg shall be HS* in header for hmac password";
+  throw new Error("sigalg shall be HS* in header for hmac password");
 
 if (prvKeyObj !== undefined && prvKeyObj instanceof rs.RSAKey &&
     ! pHeader.alg.match(/^[PR]S/))
-  throw "sigalg shall be PS* or RS* in header for RSA key";
+  throw new Error("sigalg shall be PS* or RS* in header for RSA key");
 
 if (prvKeyObj !== undefined && prvKeyObj instanceof rs.crypto.ECDSA &&
     ! pHeader.alg.match(/^ES/))
-  throw "sigalg shall be ES* in header for ECDSA key: " + pHeader.alg;
+  throw new Error("sigalg shall be ES* in header for ECDSA key: " + pHeader.alg);
 
 /*
  * sign JWS

--- a/sample_node/jwtverify
+++ b/sample_node/jwtverify
@@ -33,7 +33,7 @@ program
   .parse(process.argv);
 
 if (program.args.length !== 1)
-  throw "wrong number of arguments";
+  throw new Error("wrong number of arguments");
 
 var jwt;
 try {
@@ -49,7 +49,7 @@ var pubKeyObj;
 var acceptField = {};
 
 if (! JWS.inArray(program.passtype, ['utf8', 'hex', 'b64', 'b64u']))
-  throw "unsupported HS* password type: " + program.passtype;
+  throw new Error("unsupported HS* password type: " + program.passtype);
 if (program.passtype !== undefined && program.pass !== undefined) {
   pass = {};
   pass[program.passtype] = program.pass;

--- a/sample_node/pemtobin
+++ b/sample_node/pemtobin
@@ -24,7 +24,7 @@ program
   .parse(process.argv);
 
 if (program.args.length !== 2)
-  throw "wrong number of arguments";
+  throw new Error("wrong number of arguments");
 
 var inFile  = program.args[0];
 var outFile = program.args[1];

--- a/sample_node/showcert
+++ b/sample_node/showcert
@@ -24,7 +24,7 @@ program
     .parse(process.argv);
 
 if (program.args.length !== 1)
-    throw "wrong number of arguments";
+    throw new Error("wrong number of arguments");
 
 var file = program.args[0];
 

--- a/test/qunit-do-jws-sign.html
+++ b/test/qunit-do-jws-sign.html
@@ -185,7 +185,7 @@ test("algorithm test: unknown algorithm", function() {
   throws(function() {
     var sJWS = KJUR.jws.JWS.sign("unknown", '{"cty":"JWT"}', '{"age": 21}');
   },
-  /^unsupported alg name: /,
+  /unsupported alg name: /,
   "raise exception 'unsupported alg name'");
 });
 

--- a/x509-1.1.js
+++ b/x509-1.1.js
@@ -533,7 +533,7 @@ X509.getPublicKeyFromCertPEM = function(sCertPEM) {
                       new BigInteger(y, 16));
         return key;
     } else {
-        throw "unsupported key";
+        throw new Error("unsupported key");
     }
 };
 
@@ -562,11 +562,11 @@ X509.getPublicKeyInfoPropOfCertPEM = function(sCertPEM) {
     // 1. Certificate ASN.1
     var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(hCert, 0); 
     if (a1.length != 3)
-        throw "malformed X.509 certificate PEM (code:001)"; // not 3 item of seq Cert
+        throw new Error("malformed X.509 certificate PEM (code:001)"); // not 3 item of seq Cert
 
     // 2. tbsCertificate
     if (hCert.substr(a1[0], 2) != "30")
-        throw "malformed X.509 certificate PEM (code:002)"; // tbsCert not seq 
+        throw new Error("malformed X.509 certificate PEM (code:002)"); // tbsCert not seq 
 
     var a2 = ASN1HEX.getPosArrayOfChildren_AtObj(hCert, a1[0]); 
 
@@ -575,18 +575,18 @@ X509.getPublicKeyInfoPropOfCertPEM = function(sCertPEM) {
     if (hCert.substr(a2[0], 2) !== "a0") idx_spi = 5;
 
     if (a2.length < idx_spi + 1)
-        throw "malformed X.509 certificate PEM (code:003)"; // no subjPubKeyInfo
+        throw new Error("malformed X.509 certificate PEM (code:003)"); // no subjPubKeyInfo
 
     var a3 = ASN1HEX.getPosArrayOfChildren_AtObj(hCert, a2[idx_spi]); 
 
     if (a3.length != 2)
-        throw "malformed X.509 certificate PEM (code:004)"; // not AlgId and PubKey
+        throw new Error("malformed X.509 certificate PEM (code:004)"); // not AlgId and PubKey
 
     // 4. AlgId
     var a4 = ASN1HEX.getPosArrayOfChildren_AtObj(hCert, a3[0]); 
 
     if (a4.length != 2)
-        throw "malformed X.509 certificate PEM (code:005)"; // not 2 item in AlgId
+        throw new Error("malformed X.509 certificate PEM (code:005)"); // not 2 item in AlgId
 
     result.algoid = ASN1HEX.getHexOfV_AtObj(hCert, a4[0]);
 
@@ -598,7 +598,7 @@ X509.getPublicKeyInfoPropOfCertPEM = function(sCertPEM) {
 
     // 5. Public Key Hex
     if (hCert.substr(a3[1], 2) != "03")
-        throw "malformed X.509 certificate PEM (code:006)"; // not bitstring
+        throw new Error("malformed X.509 certificate PEM (code:006)"); // not bitstring
 
     var unusedBitAndKeyHex = ASN1HEX.getHexOfV_AtObj(hCert, a3[1]);
     result.keyhex = unusedBitAndKeyHex.substr(2);
@@ -622,17 +622,17 @@ X509.getPublicKeyInfoPosOfCertHEX = function(hCert) {
     // 1. Certificate ASN.1
     var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(hCert, 0); 
     if (a1.length != 3)
-        throw "malformed X.509 certificate PEM (code:001)"; // not 3 item of seq Cert
+        throw new Error("malformed X.509 certificate PEM (code:001)"); // not 3 item of seq Cert
 
     // 2. tbsCertificate
     if (hCert.substr(a1[0], 2) != "30")
-        throw "malformed X.509 certificate PEM (code:002)"; // tbsCert not seq 
+        throw new Error("malformed X.509 certificate PEM (code:002)"); // tbsCert not seq 
 
     var a2 = ASN1HEX.getPosArrayOfChildren_AtObj(hCert, a1[0]); 
 
     // 3. subjectPublicKeyInfo
     if (a2.length < 7)
-        throw "malformed X.509 certificate PEM (code:003)"; // no subjPubKeyInfo
+        throw new Error("malformed X.509 certificate PEM (code:003)"); // no subjPubKeyInfo
     
     return a2[6];
 };
@@ -666,29 +666,29 @@ X509.getV3ExtInfoListOfCertHex = function(hCert) {
     // 1. Certificate ASN.1
     var a1 = ASN1HEX.getPosArrayOfChildren_AtObj(hCert, 0); 
     if (a1.length != 3)
-        throw "malformed X.509 certificate PEM (code:001)"; // not 3 item of seq Cert
+        throw new Error("malformed X.509 certificate PEM (code:001)"); // not 3 item of seq Cert
 
     // 2. tbsCertificate
     if (hCert.substr(a1[0], 2) != "30")
-        throw "malformed X.509 certificate PEM (code:002)"; // tbsCert not seq 
+        throw new Error("malformed X.509 certificate PEM (code:002)"); // tbsCert not seq 
 
     var a2 = ASN1HEX.getPosArrayOfChildren_AtObj(hCert, a1[0]); 
 
     // 3. v3Extension EXPLICIT Tag [3]
     // ver, seri, alg, iss, validity, subj, spki, (iui,) (sui,) ext
     if (a2.length < 8)
-        throw "malformed X.509 certificate PEM (code:003)"; // tbsCert num field too short
+        throw new Error("malformed X.509 certificate PEM (code:003)"); // tbsCert num field too short
 
     if (hCert.substr(a2[7], 2) != "a3")
-        throw "malformed X.509 certificate PEM (code:004)"; // not [3] tag
+        throw new Error("malformed X.509 certificate PEM (code:004)"); // not [3] tag
 
     var a3 = ASN1HEX.getPosArrayOfChildren_AtObj(hCert, a2[7]);
     if (a3.length != 1)
-        throw "malformed X.509 certificate PEM (code:005)"; // [3]tag numChild!=1
+        throw new Error("malformed X.509 certificate PEM (code:005)"); // [3]tag numChild!=1
 
     // 4. v3Extension SEQUENCE
     if (hCert.substr(a3[0], 2) != "30")
-        throw "malformed X.509 certificate PEM (code:006)"; // not SEQ
+        throw new Error("malformed X.509 certificate PEM (code:006)"); // not SEQ
 
     var a4 = ASN1HEX.getPosArrayOfChildren_AtObj(hCert, a3[0]);
 
@@ -732,11 +732,11 @@ X509.getV3ExtItemInfo_AtObj = function(hCert, pos) {
 
     var a  = ASN1HEX.getPosArrayOfChildren_AtObj(hCert, pos);
     if (a.length != 2 && a.length != 3)
-        throw "malformed X.509v3 Ext (code:001)"; // oid,(critical,)val
+        throw new Error("malformed X.509v3 Ext (code:001)"); // oid,(critical,)val
 
     // oid - extension OID
     if (hCert.substr(a[0], 2) != "06")
-        throw "malformed X.509v3 Ext (code:002)"; // not OID "06"
+        throw new Error("malformed X.509v3 Ext (code:002)"); // not OID "06"
     var valueHex = ASN1HEX.getHexOfV_AtObj(hCert, a[0]);
     info.oid = ASN1HEX.hextooidstr(valueHex); 
 
@@ -748,7 +748,7 @@ X509.getV3ExtItemInfo_AtObj = function(hCert, pos) {
     //        octet string of V3 extension value.
     var posExtV = a[a.length - 1];
     if (hCert.substr(posExtV, 2) != "04")
-        throw "malformed X.509v3 Ext (code:003)"; // not EncapOctet "04"
+        throw new Error("malformed X.509v3 Ext (code:003)"); // not EncapOctet "04"
     info.posV = ASN1HEX.getStartPosOfV_AtObj(hCert, posExtV);
     
     return info;
@@ -873,7 +873,7 @@ X509.getExtBasicConstraints = function(hCert) {
 	var pathLen = parseInt(pathLexHex, 16);
 	return { "cA": true, "pathLen": pathLen };
     }
-    throw "unknown error";
+    throw new Error("unknown error");
 };
 
 X509.KEYUSAGE_NAME = [
@@ -913,7 +913,7 @@ X509.getExtKeyUsageBin = function(hCert) {
     var hKeyUsage = X509.getHexOfV_V3ExtValue(hCert, "keyUsage");
     if (hKeyUsage == '') return '';
     if (hKeyUsage.length % 2 != 0 || hKeyUsage.length <= 2)
-	throw "malformed key usage value";
+	throw new Error("malformed key usage value");
     var unusedBits = parseInt(hKeyUsage.substr(0, 2));
     var bKeyUsage = parseInt(hKeyUsage.substr(2), 16).toString(2);
     return bKeyUsage.substr(0, bKeyUsage.length - unusedBits);
@@ -1153,14 +1153,14 @@ X509.getExtAIAInfo = function(hCert) {
     var pos1 = X509.getPosOfTLV_V3ExtValue(hCert, "authorityInfoAccess");
     if (pos1 == -1) return null;
     if (hCert.substr(pos1, 2) != "30") // extnValue SEQUENCE
-	throw "malformed AIA Extn Value";
+	throw new Error("malformed AIA Extn Value");
     
     var posAccDescList = ASN1HEX.getPosArrayOfChildren_AtObj(hCert, pos1);
     for (var i = 0; i < posAccDescList.length; i++) {
 	var p = posAccDescList[i];
 	var posAccDescChild = ASN1HEX.getPosArrayOfChildren_AtObj(hCert, p);
 	if (posAccDescChild.length != 2)
-	    throw "malformed AccessDescription of AIA Extn";
+	    throw new Error("malformed AccessDescription of AIA Extn");
 	var pOID = posAccDescChild[0];
 	var pName = posAccDescChild[1];
 	if (ASN1HEX.getHexOfV_AtObj(hCert, pOID) == "2b06010505073001") {
@@ -1213,7 +1213,7 @@ X509.getSignatureAlgorithmName = function(hCert) {
 X509.getSignatureValueHex = function(hCert) {
     var h = ASN1HEX.getDecendantHexVByNthList(hCert, 0, [2]);
     if (h.substr(0, 2) !== "00")
-	throw "can't get signature value";
+	throw new Error("can't get signature value");
     return h.substr(2);
 };
 


### PR DESCRIPTION
I'm using jsrsasign inside redux-saga which led to a hard-to-diagnose bug today (`uncaught undefined` with an unhelpful stack trace).  It would have been easier to figure out if jsrsasign threw `Error`s instead of strings.
