### PR TITLE
Removed usage of RegExp.- because it is deprecated in JavaScript

### DIFF
--- a/asn1x509-1.0.js
+++ b/asn1x509-1.0.js
@@ -1265,8 +1265,9 @@ KJUR.asn1.x509.AttributeTypeAndValue = function(params) {
     var defaultDSType = "utf8";
 
     this.setByString = function(attrTypeAndValueStr) {
-        if (attrTypeAndValueStr.match(/^([^=]+)=(.+)$/)) {
-            this.setByAttrTypeAndValueStr(RegExp.$1, RegExp.$2);
+        var matchResult = attrTypeAndValueStr.match(/^([^=]+)=(.+)$/);
+        if (matchResult) {
+            this.setByAttrTypeAndValueStr(matchResult[1], matchResult[2]);
         } else {
             throw "malformed attrTypeAndValueStr: " + attrTypeAndValueStr;
         }

--- a/crypto-1.1.js
+++ b/crypto-1.1.js
@@ -818,9 +818,10 @@ KJUR.crypto.Signature = function(params) {
     var hSign = null;
 
     this._setAlgNames = function() {
-	if (this.algName.match(/^(.+)with(.+)$/)) {
-	    this.mdAlgName = RegExp.$1.toLowerCase();
-	    this.pubkeyAlgName = RegExp.$2.toLowerCase();
+    var matchResult = this.algName.match(/^(.+)with(.+)$/);
+	if (matchResult) {
+	    this.mdAlgName = matchResult[1].toLowerCase();
+	    this.pubkeyAlgName = matchResult[2].toLowerCase();
 	}
     };
 

--- a/jws-3.3.js
+++ b/jws-3.3.js
@@ -134,12 +134,13 @@ KJUR.jws.JWS = function() {
 	    (sigValNotNeeded || (this.parsedJWS.sigvalH !== undefined))) {
 	    return;
 	}
-	if (sJWS.match(/^([^.]+)\.([^.]+)\.([^.]+)$/) == null) {
+    var matchResult = sJWS.match(/^([^.]+)\.([^.]+)\.([^.]+)$/);
+	if (matchResult == null) {
 	    throw "JWS signature is not a form of 'Head.Payload.SigValue'.";
 	}
-	var b6Head = RegExp.$1;
-	var b6Payload = RegExp.$2;
-	var b6SigVal = RegExp.$3;
+	var b6Head = matchResult[1];
+	var b6Payload = matchResult[2];
+	var b6SigVal = matchResult[3];
 	var sSI = b6Head + "." + b6Payload;
 	this.parsedJWS = {};
 	this.parsedJWS.headB64U = b6Head;
@@ -849,10 +850,11 @@ KJUR.jws.JWS.readSafeJSONString = function(s) {
  * @throws if sJWS is not comma separated string such like "Header.Payload.Signature".
  */
 KJUR.jws.JWS.getEncodedSignatureValueFromJWS = function(sJWS) {
-    if (sJWS.match(/^[^.]+\.[^.]+\.([^.]+)$/) == null) {
+    var matchResult = sJWS.match(/^[^.]+\.[^.]+\.([^.]+)$/);
+    if (matchResult == null) {
 	throw "JWS signature is not a form of 'Head.Payload.SigValue'.";
     }
-    return RegExp.$1;
+    return matchResult[1];
 };
 
 /**
@@ -990,9 +992,9 @@ KJUR.jws.IntDate.get = function(s) {
  * KJUR.jws.IntDate.getZulu("151012125959Z") => 1478...
  */
 KJUR.jws.IntDate.getZulu = function(s) {
-    var a;
-    if (a = s.match(/(\d+)(\d\d)(\d\d)(\d\d)(\d\d)(\d\d)Z/)) {
-        var sYear = RegExp.$1;
+    var matchResult = s.match(/(\d+)(\d\d)(\d\d)(\d\d)(\d\d)(\d\d)Z/);
+    if (matchResult) {
+        var sYear = matchResult[1];
 	var year = parseInt(sYear);
 	if (sYear.length == 4) {
         } else if (sYear.length == 2) {
@@ -1006,11 +1008,11 @@ KJUR.jws.IntDate.getZulu = function(s) {
 	} else {
 	    throw "malformed year string";
 	}
-	var month = parseInt(RegExp.$2) - 1;
-	var day = parseInt(RegExp.$3);
-	var hour = parseInt(RegExp.$4);
-	var min = parseInt(RegExp.$5);
-	var sec = parseInt(RegExp.$6);
+	var month = parseInt(matchResult[2]) - 1;
+	var day = parseInt(matchResult[3]);
+	var hour = parseInt(matchResult[4]);
+	var min = parseInt(matchResult[5]);
+	var sec = parseInt(matchResult[6]);
 	var d = new Date(Date.UTC(year, month, day, hour, min, sec));
 	return ~~(d / 1000);
     }

--- a/keyutil-1.0.js
+++ b/keyutil-1.0.js
@@ -173,12 +173,14 @@ var KEYUTIL = function() {
 
     var _parsePKCS5PEM = function(sPKCS5PEM) {
         var info = {};
-        if (sPKCS5PEM.match(new RegExp("DEK-Info: ([^,]+),([0-9A-Fa-f]+)", "m"))) {
-            info.cipher = RegExp.$1;
-            info.ivsalt = RegExp.$2;
+        var matchResult1 = sPKCS5PEM.match(new RegExp("DEK-Info: ([^,]+),([0-9A-Fa-f]+)", "m"));
+        if (matchResult1) {
+            info.cipher = matchResult1[1];
+            info.ivsalt = matchResult1[2];
         }
-        if (sPKCS5PEM.match(new RegExp("-----BEGIN ([A-Z]+) PRIVATE KEY-----"))) {
-            info.type = RegExp.$1;
+        var matchResult2 = sPKCS5PEM.match(new RegExp("-----BEGIN ([A-Z]+) PRIVATE KEY-----"));
+        if (matchResult2) {
+            info.type = matchResult2[1];
         }
         var i1 = -1;
         var lenNEWLINE = 0;

--- a/pkcs5pkey-1.0.js
+++ b/pkcs5pkey-1.0.js
@@ -147,12 +147,14 @@ var PKCS5PKEY = function() {
 
     var _parsePKCS5PEM = function(sPKCS5PEM) {
         var info = {};
-        if (sPKCS5PEM.match(new RegExp("DEK-Info: ([^,]+),([0-9A-Fa-f]+)", "m"))) {
-            info.cipher = RegExp.$1;
-            info.ivsalt = RegExp.$2;
+        var matchResult1 = sPKCS5PEM.match(new RegExp("DEK-Info: ([^,]+),([0-9A-Fa-f]+)", "m"));
+        if (matchResult1) {
+            info.cipher = matchResult1[1];
+            info.ivsalt = matchResult1[2];
         }
-        if (sPKCS5PEM.match(new RegExp("-----BEGIN ([A-Z]+) PRIVATE KEY-----"))) {
-            info.type = RegExp.$1;
+        var matchResult2 = sPKCS5PEM.match(new RegExp("-----BEGIN ([A-Z]+) PRIVATE KEY-----"));
+        if (matchResult2) {
+            info.type = matchResult2[1];
         }
         var i1 = -1;
         var lenNEWLINE = 0;


### PR DESCRIPTION
Removed usage of RegExp.$1-$9 because it is deprecated in JavaScript (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#RegExp_Properties). I am actually running the library in an environment that does not have support for RegExp.$1-$9. Because of this I keep getting error 'TypeError: Cannot access member 'toLowerCase' of undefined'. After this change the error is gone.