### PR TITLE
Fixed the order of the minified files in the Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+yuicompressor-2.4.8.jar
+jsrsasign-4.9.0-mdcone-all-min.js

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,65 @@
-all: join-main
+.PHONY: all
 
-join-minify: *min.js ext/*min.js npm/lib/header.js npm/lib/footer.js
-	cat *min.js $(shell find ext/ -name "*min.js") | sed "s/\/*! /\n\/*! /g" > jsrsasign-4.9.0-mdcone-all-min.js
-	cp jsrsasign-4.9.0-mdcone-all-min.js jsrsasign-latest-all-min.js
+FILES = \
+	jsrsasign-header.js \
+	ext/yahoo-min.js \
+	ext/cj/cryptojs-312-core-fix-min.js \
+	ext/cj/x64-core_min.js \
+	ext/cj/cipher-core_min.js \
+	ext/cj/aes_min.js \
+	ext/cj/tripledes_min.js \
+	ext/cj/enc-base64_min.js \
+	ext/cj/md5_min.js \
+	ext/cj/sha1_min.js \
+	ext/cj/sha256_min.js \
+	ext/cj/sha224_min.js \
+	ext/cj/sha512_min.js \
+	ext/cj/sha384_min.js \
+	ext/cj/ripemd160_min.js \
+	ext/cj/hmac_min.js \
+	ext/cj/pbkdf2_min.js \
+	ext/base64-min.js \
+	ext/jsbn-min.js \
+	ext/jsbn2-min.js \
+	ext/prng4-min.js \
+	ext/rng-min.js \
+	ext/rsa-min.js \
+	ext/rsa2-min.js \
+	ext/ec-min.js \
+	ext/ec-patch-min.js \
+	ext/json-sans-eval-min.js \
+	min/asn1-1.0.min.js \
+	min/asn1hex-1.1.min.js \
+	min/asn1x509-1.0.min.js \
+	min/asn1cms-1.0.min.js \
+	min/asn1tsp-1.0.min.js \
+	min/asn1cades-1.0.min.js \
+	min/asn1csr-1.0.min.js \
+	min/asn1ocsp-1.0.min.js \
+	min/base64x-1.1.min.js \
+	min/crypto-1.1.min.js \
+	min/ecdsa-modified-1.0.min.js \
+	min/ecparam-1.0.min.js \
+	min/dsa-modified-1.0.min.js \
+	min/pkcs5pkey-1.0.min.js \
+	min/keyutil-1.0.min.js \
+	min/rsapem-1.1.min.js \
+	min/rsasign-1.2.min.js \
+	min/x509-1.1.min.js \
+	min/jws-3.3.min.js \
+	min/jwsjs-2.0.min.js
 
-#min-js: *.js
-#	for i in `ls *.js | grep -v "min.js"` ; do java -jar ~/src/yuicompressor/build/yuicompressor-2.4.8.jar $i -o `echo $i | sed 's/.js/-min.js/g'` ; done
 
-join-main: join-minify
-	cat \
-        npm/lib/header.js \
-        jsrsasign-latest-all-min.js \
-        npm/lib/footer.js \
-        > npm/lib/jsrsasign.js
+min/%.min.js: %.js
+	java -jar ./yuicompressor-2.4.8.jar $^ -o $@
+
+
+all: npm/lib/jsrsasign.js min/nodeutil-1.0.min.js
+
+jsrsasign-latest-all-min.js: $(FILES)
+	cat $^ | sed "s/\/\*! /\n\/\*! /g" > jsrsasign-4.9.0-mdcone-all-min.js
+	cp jsrsasign-4.9.0-mdcone-all-min.js $@
+
+npm/lib/jsrsasign.js: npm/lib/header.js jsrsasign-latest-all-min.js npm/lib/footer.js
+	cat $^ > $@
+

--- a/jsrsasign-header.js
+++ b/jsrsasign-header.js
@@ -1,0 +1,4 @@
+/*
+ * jsrsasign 6.1.4 (2016-10-16) (c) 2010-2016 Kenji Urushima | kjur.github.com/jsrsasign/license
+ */
+

--- a/npm_util/Makefile
+++ b/npm_util/Makefile
@@ -1,10 +1,10 @@
-all:
-	echo aaa
+.PHONY: all aaa
 
-aaa:
-	cat \
-	lib/header.js \
-	../min/nodeutil-1.0.min.js \
-	lib/footer.js \
-	> lib/jsrsasign-util.js
+all:
+	@echo aaa
+
+aaa: lib/jsrsasign-util.js
+
+lib/jsrsasign-util.js: lib/header.js ../min/nodeutil-1.0.min.js lib/footer.js
+	cat $^ > $@
 


### PR DESCRIPTION
The minified version rely on the order of the files, but the `Makefile` was using `cat *` which doesn't have a reliable order.