### PR TITLE
Support any attribute OID in DName

### DIFF
--- a/asn1x509-1.0.js
+++ b/asn1x509-1.0.js
@@ -2000,9 +2000,11 @@ KJUR.asn1.x509.OID = new function(params) {
     this.atype2obj = function(atype) {
         if (typeof this.objCache[atype] != "undefined")
             return this.objCache[atype];
+        var oid;
         if (typeof this.atype2oidList[atype] == "undefined")
-            throw "AttributeType name undefined: " + atype;
-        var oid = this.atype2oidList[atype];
+            oid = atype;//throw "AttributeType name undefined: " + atype;
+        else
+            oid = this.atype2oidList[atype];
         var obj = new KJUR.asn1.DERObjectIdentifier({'oid': oid});
         this.objCache[atype] = obj;
         return obj;


### PR DESCRIPTION
This patch allows one to add any OID name-value pair in a DName structure.