### PR TITLE
Remove unnecessary reference to RSAKey in JWS.sign

### DIFF
--- a/src/jws-3.3.js
+++ b/src/jws-3.3.js
@@ -243,7 +243,6 @@ KJUR.jws.JWS.sign = function(alg, spHeader, spPayload, key, pass) {
 	_ECDSA = _KJUR_crypto.ECDSA,
 	_Mac = _KJUR_crypto.Mac,
 	_Signature = _KJUR_crypto.Signature,
-	_RSAKey = RSAKey,
 	_JSON = JSON;
 
     var sHeader, pHeader, sPayload;


### PR DESCRIPTION
Hi Kenji Urushima-san,

Could you tell me why do you need to have a reference to `RSAKey` in `KJUR.jws.JWS.sign` (at line 246: https://github.com/kjur/jsrsasign/blob/master/src/jws-3.3.js#L246)?

As far as I can tell, `sign` doesn't use `_RSAKey`. However, having the reference here, the browser throw an error when I tried to use the jwt subset (https://github.com/kjur/jsrsasign/blob/master/jsrsasign-jwths-min.js) since there is no 'RSAKey' defined

<img width="637" alt="screen shot 2017-06-11 at 8 32 20 am" src="https://user-images.githubusercontent.com/5953369/27007064-86e2e68e-4e80-11e7-99b5-33589186c0c2.png">

Should we remove this reference? If so, should we remove it in general or just in the subset?