### PR TITLE
A fix for jsrsasign issue #270, removing duplicate export of "b64tohex"

### DIFF
--- a/npm/lib/jsrsasign.js
+++ b/npm/lib/jsrsasign.js
@@ -283,7 +283,6 @@ exports.b64utob64 = b64utob64;
 exports.hex2b64 = hex2b64;
 exports.hextob64u = hextob64u;
 exports.b64utohex = b64utohex;
-exports.b64tohex = b64tohex;
 exports.utf8tob64u = utf8tob64u;
 exports.b64utoutf8 = b64utoutf8;
 exports.utf8tob64 = utf8tob64;


### PR DESCRIPTION
The title says it all, really. Fixes issue #270.