### PR TITLE
Fix function documentation and examples

### DIFF
--- a/src/base64x-1.1.js
+++ b/src/base64x-1.1.js
@@ -10,7 +10,7 @@
  * This software is licensed under the terms of the MIT License.
  * http://kjur.github.com/jsjws/license/
  *
- * The above copyright and license notice shall be 
+ * The above copyright and license notice shall be
  * included in all copies or substantial portions of the Software.
  *
  * DEPENDS ON:
@@ -70,7 +70,7 @@ KJUR.lang.String = function() {};
  * </ul>
  * All functions in 'base64x.js' are defined in {@link _global_} and not
  * in this class.
- * 
+ *
  * @class Base64URL and supplementary functions for Tom Wu's base64.js library
  * @author Kenji Urushima
  * @version 1.1 (07 May 2012)
@@ -87,7 +87,7 @@ function Base64x() {
  * @name stoBA
  * @function
  * @param {String} s
- * @return {Array of Numbers} 
+ * @return {Array of Numbers}
  */
 function stoBA(s) {
     var a = new Array();
@@ -438,7 +438,7 @@ function b64nltohex(s) {
     var b64 = s.replace(/[^0-9A-Za-z\/+=]*/g, '');
     var hex = b64tohex(b64);
     return hex;
-} 
+}
 
 // ==== hex / pem =========================================
 
@@ -461,8 +461,8 @@ function b64nltohex(s) {
  */
 function hextopem(dataHex, pemHeader) {
     var pemBody = hextob64nl(dataHex);
-    return "-----BEGIN " + pemHeader + "-----\r\n" + 
-        pemBody + 
+    return "-----BEGIN " + pemHeader + "-----\r\n" +
+        pemBody +
         "\r\n-----END " + pemHeader + "-----\r\n";
 }
 
@@ -475,13 +475,13 @@ function hextopem(dataHex, pemHeader) {
  * @return {String} hexadecimal string data of PEM contents
  * @since jsrsasign 7.2.1 base64x 1.1.12
  * @description
- * This static method gets a hexacedimal string of contents 
- * from PEM format data. You can explicitly specify PEM header 
- * by sHead argument. 
+ * This static method gets a hexacedimal string of contents
+ * from PEM format data. You can explicitly specify PEM header
+ * by sHead argument.
  * Any space characters such as white space or new line
  * will be omitted.<br/>
  * NOTE: Now {@link KEYUTIL.getHexFromPEM} and {@link X509.pemToHex}
- * have been deprecated since jsrsasign 7.2.1. 
+ * have been deprecated since jsrsasign 7.2.1.
  * Please use this method instead.
  * @example
  * pemtohex("-----BEGIN PUBLIC KEY...") &rarr; "3082..."
@@ -505,21 +505,16 @@ function pemtohex(s, sHead) {
 // ==== hex / ArrayBuffer =================================
 
 /**
- * convert a ArrayBuffer to a hexadecimal string<br/>
+ * convert a hexadecimal string to an ArrayBuffer<br/>
  * @name hextoArrayBuffer
  * @function
  * @param {String} hex hexadecimal string
  * @return {ArrayBuffer} ArrayBuffer
  * @since jsrsasign 6.1.4 base64x 1.1.8
  * @description
- * This function converts from a ArrayBuffer to a hexadecimal string.
+ * This function converts from a hexadecimal string to an ArrayBuffer.
  * @example
- * var buffer = new ArrayBuffer(3);
- * var view = new DataView(buffer);
- * view.setUint8(0, 0xfa);
- * view.setUint8(1, 0xfb);
- * view.setUint8(2, 0x01);
- * ArrayBuffertohex(buffer) &rarr; "fafb01"
+ * hextoArrayBuffer("fffa01") &rarr; ArrayBuffer of [255, 250, 1]
  */
 function hextoArrayBuffer(hex) {
     if (hex.length % 2 != 0) throw "input is not even length";
@@ -538,16 +533,21 @@ function hextoArrayBuffer(hex) {
 // ==== ArrayBuffer / hex =================================
 
 /**
- * convert a ArrayBuffer to a hexadecimal string<br/>
+ * convert an ArrayBuffer to a hexadecimal string<br/>
  * @name ArrayBuffertohex
  * @function
  * @param {ArrayBuffer} buffer ArrayBuffer
  * @return {String} hexadecimal string
  * @since jsrsasign 6.1.4 base64x 1.1.8
  * @description
- * This function converts from a ArrayBuffer to a hexadecimal string.
+ * This function converts from an ArrayBuffer to a hexadecimal string.
  * @example
- * hextoArrayBuffer("fffa01") &rarr; ArrayBuffer of [255, 250, 1]
+ * var buffer = new ArrayBuffer(3);
+ * var view = new DataView(buffer);
+ * view.setUint8(0, 0xfa);
+ * view.setUint8(1, 0xfb);
+ * view.setUint8(2, 0x01);
+ * ArrayBuffertohex(buffer) &rarr; "fafb01"
  */
 function ArrayBuffertohex(buffer) {
     var hex = "";
@@ -571,7 +571,7 @@ function ArrayBuffertohex(buffer) {
  * @description
  * This function converts from GeneralizedTime string (i.e. YYYYMMDDHHmmSSZ) or
  * UTCTime string (i.e. YYMMDDHHmmSSZ) to milliseconds from Unix origin time
- * (i.e. Jan 1 1970 0:00:00 UTC). 
+ * (i.e. Jan 1 1970 0:00:00 UTC).
  * Argument string may have fraction of seconds and
  * its length is one or more digits such as "20170410235959.1234567Z".
  * As for UTCTime, if year "YY" is equal or less than 49 then it is 20YY.
@@ -626,7 +626,7 @@ function zulutomsec(s) {
  * @description
  * This function converts from GeneralizedTime string (i.e. YYYYMMDDHHmmSSZ) or
  * UTCTime string (i.e. YYMMDDHHmmSSZ) to seconds from Unix origin time
- * (i.e. Jan 1 1970 0:00:00 UTC). Argument string may have fraction of seconds 
+ * (i.e. Jan 1 1970 0:00:00 UTC). Argument string may have fraction of seconds
  * however result value will be omitted.
  * As for UTCTime, if year "YY" is equal or less than 49 then it is 20YY.
  * If year "YY" is equal or greater than 50 then it is 19YY.
@@ -683,7 +683,7 @@ function zulutodate(s) {
  * As for UTCTime, if year "YY" is equal or less than 49 then it is 20YY.
  * If year "YY" is equal or greater than 50 then it is 19YY.
  * If flagMilli is true its result concludes milliseconds such like
- * "20170520235959.42Z". 
+ * "20170520235959.42Z".
  * @example
  * d = new Date(Date.UTC(2017,4,20,23,59,59,670));
  * datetozulu(d) &rarr; "20170520235959Z"
@@ -694,7 +694,7 @@ function datetozulu(d, flagUTCTime, flagMilli) {
     var s;
     var year = d.getUTCFullYear();
     if (flagUTCTime) {
-	if (year < 1950 || 2049 < year) 
+	if (year < 1950 || 2049 < year)
 	    throw "not proper year for UTCTime: " + year;
 	s = ("" + year).slice(-2);
     } else {
@@ -747,7 +747,7 @@ function hextouricmp(s) {
  * convert UTFa hexadecimal string to a URLComponent string such like "%67%68".<br/>
  * Note that these "<code>0-9A-Za-z!'()*-._~</code>" characters will not
  * converted to "%xx" format by builtin 'encodeURIComponent()' function.
- * However this 'encodeURIComponentAll()' function will convert 
+ * However this 'encodeURIComponentAll()' function will convert
  * all of characters into "%xx" format.
  * @name encodeURIComponentAll
  * @function
@@ -771,11 +771,11 @@ function encodeURIComponentAll(u8) {
 
 // ==== new lines ================================
 /**
- * convert all DOS new line("\r\n") to UNIX new line("\n") in 
+ * convert all DOS new line("\r\n") to UNIX new line("\n") in
  * a String "s".
  * @name newline_toUnix
  * @function
- * @param {String} s string 
+ * @param {String} s string
  * @return {String} converted string
  */
 function newline_toUnix(s) {
@@ -784,11 +784,11 @@ function newline_toUnix(s) {
 }
 
 /**
- * convert all UNIX new line("\r\n") to DOS new line("\n") in 
+ * convert all UNIX new line("\r\n") to DOS new line("\n") in
  * a String "s".
  * @name newline_toDos
  * @function
- * @param {String} s string 
+ * @param {String} s string
  * @return {String} converted string
  */
 function newline_toDos(s) {
@@ -922,7 +922,7 @@ KJUR.lang.String.isIntegerArray = function(s) {
  * canonicalize hexadecimal string of positive integer<br/>
  * @name hextoposhex
  * @function
- * @param {String} s hexadecimal string 
+ * @param {String} s hexadecimal string
  * @return {String} canonicalized hexadecimal string of positive integer
  * @since base64x 1.1.10 jsrsasign 7.1.4
  * @description
@@ -956,10 +956,10 @@ function hextoposhex(s) {
  * @throws "malformed integer array string: *" for wrong input
  * @description
  * This function converts a string of JavaScript integer array to
- * a hexadecimal string. Each integer value shall be in a range 
+ * a hexadecimal string. Each integer value shall be in a range
  * from 0 to 255 otherwise it raise exception. Input string can
  * have extra space or newline string so that they will be ignored.
- * 
+ *
  * @example
  * intarystrtohex(" [123, 34, 101, 34, 58] ")
  * &rarr; 7b2265223a (i.e. '{"e":' as string)

--- a/src/base64x-1.1.js
+++ b/src/base64x-1.1.js
@@ -10,7 +10,7 @@
  * This software is licensed under the terms of the MIT License.
  * http://kjur.github.com/jsjws/license/
  *
- * The above copyright and license notice shall be
+ * The above copyright and license notice shall be 
  * included in all copies or substantial portions of the Software.
  *
  * DEPENDS ON:
@@ -70,7 +70,7 @@ KJUR.lang.String = function() {};
  * </ul>
  * All functions in 'base64x.js' are defined in {@link _global_} and not
  * in this class.
- *
+ * 
  * @class Base64URL and supplementary functions for Tom Wu's base64.js library
  * @author Kenji Urushima
  * @version 1.1 (07 May 2012)
@@ -87,7 +87,7 @@ function Base64x() {
  * @name stoBA
  * @function
  * @param {String} s
- * @return {Array of Numbers}
+ * @return {Array of Numbers} 
  */
 function stoBA(s) {
     var a = new Array();
@@ -438,7 +438,7 @@ function b64nltohex(s) {
     var b64 = s.replace(/[^0-9A-Za-z\/+=]*/g, '');
     var hex = b64tohex(b64);
     return hex;
-}
+} 
 
 // ==== hex / pem =========================================
 
@@ -461,8 +461,8 @@ function b64nltohex(s) {
  */
 function hextopem(dataHex, pemHeader) {
     var pemBody = hextob64nl(dataHex);
-    return "-----BEGIN " + pemHeader + "-----\r\n" +
-        pemBody +
+    return "-----BEGIN " + pemHeader + "-----\r\n" + 
+        pemBody + 
         "\r\n-----END " + pemHeader + "-----\r\n";
 }
 
@@ -475,13 +475,13 @@ function hextopem(dataHex, pemHeader) {
  * @return {String} hexadecimal string data of PEM contents
  * @since jsrsasign 7.2.1 base64x 1.1.12
  * @description
- * This static method gets a hexacedimal string of contents
- * from PEM format data. You can explicitly specify PEM header
- * by sHead argument.
+ * This static method gets a hexacedimal string of contents 
+ * from PEM format data. You can explicitly specify PEM header 
+ * by sHead argument. 
  * Any space characters such as white space or new line
  * will be omitted.<br/>
  * NOTE: Now {@link KEYUTIL.getHexFromPEM} and {@link X509.pemToHex}
- * have been deprecated since jsrsasign 7.2.1.
+ * have been deprecated since jsrsasign 7.2.1. 
  * Please use this method instead.
  * @example
  * pemtohex("-----BEGIN PUBLIC KEY...") &rarr; "3082..."
@@ -571,7 +571,7 @@ function ArrayBuffertohex(buffer) {
  * @description
  * This function converts from GeneralizedTime string (i.e. YYYYMMDDHHmmSSZ) or
  * UTCTime string (i.e. YYMMDDHHmmSSZ) to milliseconds from Unix origin time
- * (i.e. Jan 1 1970 0:00:00 UTC).
+ * (i.e. Jan 1 1970 0:00:00 UTC). 
  * Argument string may have fraction of seconds and
  * its length is one or more digits such as "20170410235959.1234567Z".
  * As for UTCTime, if year "YY" is equal or less than 49 then it is 20YY.
@@ -626,7 +626,7 @@ function zulutomsec(s) {
  * @description
  * This function converts from GeneralizedTime string (i.e. YYYYMMDDHHmmSSZ) or
  * UTCTime string (i.e. YYMMDDHHmmSSZ) to seconds from Unix origin time
- * (i.e. Jan 1 1970 0:00:00 UTC). Argument string may have fraction of seconds
+ * (i.e. Jan 1 1970 0:00:00 UTC). Argument string may have fraction of seconds 
  * however result value will be omitted.
  * As for UTCTime, if year "YY" is equal or less than 49 then it is 20YY.
  * If year "YY" is equal or greater than 50 then it is 19YY.
@@ -683,7 +683,7 @@ function zulutodate(s) {
  * As for UTCTime, if year "YY" is equal or less than 49 then it is 20YY.
  * If year "YY" is equal or greater than 50 then it is 19YY.
  * If flagMilli is true its result concludes milliseconds such like
- * "20170520235959.42Z".
+ * "20170520235959.42Z". 
  * @example
  * d = new Date(Date.UTC(2017,4,20,23,59,59,670));
  * datetozulu(d) &rarr; "20170520235959Z"
@@ -694,7 +694,7 @@ function datetozulu(d, flagUTCTime, flagMilli) {
     var s;
     var year = d.getUTCFullYear();
     if (flagUTCTime) {
-	if (year < 1950 || 2049 < year)
+	if (year < 1950 || 2049 < year) 
 	    throw "not proper year for UTCTime: " + year;
 	s = ("" + year).slice(-2);
     } else {
@@ -747,7 +747,7 @@ function hextouricmp(s) {
  * convert UTFa hexadecimal string to a URLComponent string such like "%67%68".<br/>
  * Note that these "<code>0-9A-Za-z!'()*-._~</code>" characters will not
  * converted to "%xx" format by builtin 'encodeURIComponent()' function.
- * However this 'encodeURIComponentAll()' function will convert
+ * However this 'encodeURIComponentAll()' function will convert 
  * all of characters into "%xx" format.
  * @name encodeURIComponentAll
  * @function
@@ -771,11 +771,11 @@ function encodeURIComponentAll(u8) {
 
 // ==== new lines ================================
 /**
- * convert all DOS new line("\r\n") to UNIX new line("\n") in
+ * convert all DOS new line("\r\n") to UNIX new line("\n") in 
  * a String "s".
  * @name newline_toUnix
  * @function
- * @param {String} s string
+ * @param {String} s string 
  * @return {String} converted string
  */
 function newline_toUnix(s) {
@@ -784,11 +784,11 @@ function newline_toUnix(s) {
 }
 
 /**
- * convert all UNIX new line("\r\n") to DOS new line("\n") in
+ * convert all UNIX new line("\r\n") to DOS new line("\n") in 
  * a String "s".
  * @name newline_toDos
  * @function
- * @param {String} s string
+ * @param {String} s string 
  * @return {String} converted string
  */
 function newline_toDos(s) {
@@ -922,7 +922,7 @@ KJUR.lang.String.isIntegerArray = function(s) {
  * canonicalize hexadecimal string of positive integer<br/>
  * @name hextoposhex
  * @function
- * @param {String} s hexadecimal string
+ * @param {String} s hexadecimal string 
  * @return {String} canonicalized hexadecimal string of positive integer
  * @since base64x 1.1.10 jsrsasign 7.1.4
  * @description
@@ -956,10 +956,10 @@ function hextoposhex(s) {
  * @throws "malformed integer array string: *" for wrong input
  * @description
  * This function converts a string of JavaScript integer array to
- * a hexadecimal string. Each integer value shall be in a range
+ * a hexadecimal string. Each integer value shall be in a range 
  * from 0 to 255 otherwise it raise exception. Input string can
  * have extra space or newline string so that they will be ignored.
- *
+ * 
  * @example
  * intarystrtohex(" [123, 34, 101, 34, 58] ")
  * &rarr; 7b2265223a (i.e. '{"e":' as string)

--- a/src/crypto-1.1.js
+++ b/src/crypto-1.1.js
@@ -8,7 +8,7 @@
  * This software is licensed under the terms of the MIT License.
  * http://kjur.github.com/jsrsasign/license
  *
- * The above copyright and license notice shall be
+ * The above copyright and license notice shall be 
  * included in all copies or substantial portions of the Software.
  */
 
@@ -21,7 +21,7 @@
  * @license <a href="http://kjur.github.io/jsrsasign/license/">MIT License</a>
  */
 
-/**
+/** 
  * kjur's class library name space
  * @name KJUR
  * @namespace kjur's class library name space
@@ -297,7 +297,7 @@ KJUR.crypto.Util.SECURERANDOMGEN = new SecureRandom();
  * @since jsrsasign 7.0.0 crypto 1.1.11
  * @example
  * KJUR.crypto.Util.getRandomHexOfNbytes(3) &rarr; "6314af", "000000" or "001fb4"
- * KJUR.crypto.Util.getRandomHexOfNbytes(128) &rarr; "8fbc..." in 1024bits
+ * KJUR.crypto.Util.getRandomHexOfNbytes(128) &rarr; "8fbc..." in 1024bits 
  */
 KJUR.crypto.Util.getRandomHexOfNbytes = function(n) {
     var ba = new Array(n);
@@ -331,7 +331,7 @@ KJUR.crypto.Util.getRandomBigIntegerOfNbytes = function(n) {
  * @since jsrsasign 7.0.0 crypto 1.1.11
  * @example
  * KJUR.crypto.Util.getRandomHexOfNbits(24) &rarr; "6314af", "000000" or "001fb4"
- * KJUR.crypto.Util.getRandomHexOfNbits(1024) &rarr; "8fbc..." in 1024bits
+ * KJUR.crypto.Util.getRandomHexOfNbits(1024) &rarr; "8fbc..." in 1024bits 
  */
 KJUR.crypto.Util.getRandomHexOfNbits = function(n) {
     var n_remainder = n % 8;
@@ -681,7 +681,7 @@ KJUR.crypto.MessageDigest.HASHLENGTH = {
 // === Mac ===============================================================
 
 /**
- * Mac(Message Authentication Code) class which is very similar to java.security.Mac class
+ * Mac(Message Authentication Code) class which is very similar to java.security.Mac class 
  * @name KJUR.crypto.Mac
  * @class Mac class which is very similar to java.security.Mac class
  * @param {Array} params parameters for constructor
@@ -710,7 +710,7 @@ KJUR.crypto.MessageDigest.HASHLENGTH = {
  * mac.updateString('aaa')
  * var macHex = mac.doFinal()
  *
- * // other password representation
+ * // other password representation 
  * var mac = new KJUR.crypto.Mac({alg: "HmacSHA256", "pass": {"hex":  "6161"}});
  * var mac = new KJUR.crypto.Mac({alg: "HmacSHA256", "pass": {"utf8": "aa"}});
  * var mac = new KJUR.crypto.Mac({alg: "HmacSHA256", "pass": {"rstr": "\x61\x61"}});
@@ -826,7 +826,7 @@ KJUR.crypto.Mac = function(params) {
     };
 
     /**
-     * performs final update on the digest using hexadecimal string,
+     * performs final update on the digest using hexadecimal string, 
      * then completes the digest computation
      * @name doFinalHex
      * @memberOf KJUR.crypto.Mac#
@@ -860,7 +860,7 @@ KJUR.crypto.Mac = function(params) {
      * <li>{b64u: "Mi7-_"}: explicitly specified as Base64URL string</li>
      * </ul>
      * It is *STRONGLY RECOMMENDED* that explicit representation of password argument
-     * to avoid ambiguity. For example string  "6161" can mean a string "6161" or
+     * to avoid ambiguity. For example string  "6161" can mean a string "6161" or 
      * a hexadecimal string of "aa" (i.e. \x61\x61).
      * @example
      * mac = KJUR.crypto.Mac({'alg': 'hmacsha256'});
@@ -900,7 +900,7 @@ KJUR.crypto.Mac = function(params) {
 
 	if (typeof pass != 'object')
 	    throw "KJUR.crypto.Mac unsupported password type: " + pass;
-
+	
 	var hPass = null;
 	if (pass.hex  !== undefined) {
 	    if (pass.hex.length % 2 != 0 || ! pass.hex.match(/^[0-9A-Fa-f]+$/))
@@ -993,7 +993,7 @@ KJUR.crypto.Mac = function(params) {
  * sig2.init(certPEM);
  * sig.updateString('aaa');
  * var isValid = sig2.verify(hSigVal);
- *
+ * 
  * // ECDSA signing
  * var sig = new KJUR.crypto.Signature({'alg':'SHA1withECDSA'});
  * sig.init(prvKeyPEM);
@@ -1066,7 +1066,7 @@ KJUR.crypto.Signature = function(params) {
 		throw "setAlgAndProvider hash alg set fail alg=" +
                     this.mdAlgName + "/" + ex;
 	    }
-
+	    
 	    this.init = function(keyparam, pass) {
 		var keyObj = null;
 		try {
@@ -1138,7 +1138,7 @@ KJUR.crypto.Signature = function(params) {
 		    return ec.verifyHex(this.sHashHex, hSigVal, this.ecpubhex);
 		} else if (this.pubKey instanceof RSAKey &&
 			   this.pubkeyAlgName == "rsaandmgf1") {
-		    return this.pubKey.verifyWithMessageHashPSS(this.sHashHex, hSigVal,
+		    return this.pubKey.verifyWithMessageHashPSS(this.sHashHex, hSigVal, 
 								this.mdAlgName,
 								this.pssSaltLen);
 		} else if (this.pubKey instanceof RSAKey &&
@@ -1334,7 +1334,7 @@ KJUR.crypto.Signature = function(params) {
  * <li>RSAOAEP512 - RSA/ECB/OAEPWithSHA-512AndMGF1Padding(*)</li>
  * </ul>
  * NOTE: (*) is not supported in Java JCE.<br/>
- * Currently this class supports only RSA encryption and decryption.
+ * Currently this class supports only RSA encryption and decryption. 
  * However it is planning to implement also symmetric ciphers near in the future.
  * @example
  */
@@ -1348,12 +1348,12 @@ KJUR.crypto.Cipher = function(params) {
  * @function
  * @param {String} s input string to encrypt
  * @param {Object} keyObj RSAKey object or hexadecimal string of symmetric cipher key
- * @param {String} algName short/long algorithm name for encryption/decryption
+ * @param {String} algName short/long algorithm name for encryption/decryption 
  * @return {String} hexadecimal encrypted string
  * @since jsrsasign 6.2.0 crypto 1.1.10
  * @description
  * This static method encrypts raw string with specified key and algorithm.
- * @example
+ * @example 
  * KJUR.crypto.Cipher.encrypt("aaa", pubRSAKeyObj) &rarr; "1abc2d..."
  * KJUR.crypto.Cipher.encrypt("aaa", pubRSAKeyObj, "RSAOAEP") &rarr; "23ab02..."
  */
@@ -1384,7 +1384,7 @@ KJUR.crypto.Cipher.encrypt = function(s, keyObj, algName) {
  * @since jsrsasign 6.2.0 crypto 1.1.10
  * @description
  * This static method decrypts encrypted hexadecimal string with specified key and algorithm.
- * @example
+ * @example 
  * KJUR.crypto.Cipher.decrypt("aaa", prvRSAKeyObj) &rarr; "1abc2d..."
  * KJUR.crypto.Cipher.decrypt("aaa", prvRSAKeyObj, "RSAOAEP) &rarr; "23ab02..."
  */
@@ -1423,7 +1423,7 @@ KJUR.crypto.Cipher.decrypt = function(hex, keyObj, algName) {
  * <li>RSAOAEP512 - RSA/ECB/OAEPWithSHA-512AndMGF1Padding(*)</li>
  * </ul>
  * NOTE: (*) is not supported in Java JCE.
- * @example
+ * @example 
  * KJUR.crypto.Cipher.getAlgByKeyAndName(objRSAKey) &rarr; "RSA"
  * KJUR.crypto.Cipher.getAlgByKeyAndName(objRSAKey, "RSAOAEP") &rarr; "RSAOAEP"
  */

--- a/src/crypto-1.1.js
+++ b/src/crypto-1.1.js
@@ -8,7 +8,7 @@
  * This software is licensed under the terms of the MIT License.
  * http://kjur.github.com/jsrsasign/license
  *
- * The above copyright and license notice shall be 
+ * The above copyright and license notice shall be
  * included in all copies or substantial portions of the Software.
  */
 
@@ -21,7 +21,7 @@
  * @license <a href="http://kjur.github.io/jsrsasign/license/">MIT License</a>
  */
 
-/** 
+/**
  * kjur's class library name space
  * @name KJUR
  * @namespace kjur's class library name space
@@ -297,7 +297,7 @@ KJUR.crypto.Util.SECURERANDOMGEN = new SecureRandom();
  * @since jsrsasign 7.0.0 crypto 1.1.11
  * @example
  * KJUR.crypto.Util.getRandomHexOfNbytes(3) &rarr; "6314af", "000000" or "001fb4"
- * KJUR.crypto.Util.getRandomHexOfNbytes(128) &rarr; "8fbc..." in 1024bits 
+ * KJUR.crypto.Util.getRandomHexOfNbytes(128) &rarr; "8fbc..." in 1024bits
  */
 KJUR.crypto.Util.getRandomHexOfNbytes = function(n) {
     var ba = new Array(n);
@@ -331,7 +331,7 @@ KJUR.crypto.Util.getRandomBigIntegerOfNbytes = function(n) {
  * @since jsrsasign 7.0.0 crypto 1.1.11
  * @example
  * KJUR.crypto.Util.getRandomHexOfNbits(24) &rarr; "6314af", "000000" or "001fb4"
- * KJUR.crypto.Util.getRandomHexOfNbits(1024) &rarr; "8fbc..." in 1024bits 
+ * KJUR.crypto.Util.getRandomHexOfNbits(1024) &rarr; "8fbc..." in 1024bits
  */
 KJUR.crypto.Util.getRandomHexOfNbits = function(n) {
     var n_remainder = n % 8;
@@ -681,7 +681,7 @@ KJUR.crypto.MessageDigest.HASHLENGTH = {
 // === Mac ===============================================================
 
 /**
- * Mac(Message Authentication Code) class which is very similar to java.security.Mac class 
+ * Mac(Message Authentication Code) class which is very similar to java.security.Mac class
  * @name KJUR.crypto.Mac
  * @class Mac class which is very similar to java.security.Mac class
  * @param {Array} params parameters for constructor
@@ -708,9 +708,9 @@ KJUR.crypto.MessageDigest.HASHLENGTH = {
  * @example
  * var mac = new KJUR.crypto.Mac({alg: "HmacSHA1", "pass": "pass"});
  * mac.updateString('aaa')
- * var macHex = md.doFinal()
+ * var macHex = mac.doFinal()
  *
- * // other password representation 
+ * // other password representation
  * var mac = new KJUR.crypto.Mac({alg: "HmacSHA256", "pass": {"hex":  "6161"}});
  * var mac = new KJUR.crypto.Mac({alg: "HmacSHA256", "pass": {"utf8": "aa"}});
  * var mac = new KJUR.crypto.Mac({alg: "HmacSHA256", "pass": {"rstr": "\x61\x61"}});
@@ -778,7 +778,7 @@ KJUR.crypto.Mac = function(params) {
      * @param {String} str string to update
      * @description
      * @example
-     * md.updateString('New York');
+     * mac.updateString('New York');
      */
     this.updateString = function(str) {
 	throw "updateString(str) not supported for this alg/prov: " + this.algProv;
@@ -792,7 +792,7 @@ KJUR.crypto.Mac = function(params) {
      * @param {String} hex hexadecimal string to update
      * @description
      * @example
-     * md.updateHex('0afe36');
+     * mac.updateHex('0afe36');
      */
     this.updateHex = function(hex) {
 	throw "updateHex(hex) not supported for this alg/prov: " + this.algProv;
@@ -805,7 +805,7 @@ KJUR.crypto.Mac = function(params) {
      * @function
      * @description
      * @example
-     * md.digest()
+     * mac.digest()
      */
     this.doFinal = function() {
 	throw "digest() not supported for this alg/prov: " + this.algProv;
@@ -819,14 +819,14 @@ KJUR.crypto.Mac = function(params) {
      * @param {String} str string to final update
      * @description
      * @example
-     * md.digestString('aaa')
+     * mac.digestString('aaa')
      */
     this.doFinalString = function(str) {
 	throw "digestString(str) not supported for this alg/prov: " + this.algProv;
     };
 
     /**
-     * performs final update on the digest using hexadecimal string, 
+     * performs final update on the digest using hexadecimal string,
      * then completes the digest computation
      * @name doFinalHex
      * @memberOf KJUR.crypto.Mac#
@@ -834,7 +834,7 @@ KJUR.crypto.Mac = function(params) {
      * @param {String} hex hexadecimal string to final update
      * @description
      * @example
-     * md.digestHex('0f2abd')
+     * mac.digestHex('0f2abd')
      */
     this.doFinalHex = function(hex) {
 	throw "digestHex(hex) not supported for this alg/prov: " + this.algProv;
@@ -860,7 +860,7 @@ KJUR.crypto.Mac = function(params) {
      * <li>{b64u: "Mi7-_"}: explicitly specified as Base64URL string</li>
      * </ul>
      * It is *STRONGLY RECOMMENDED* that explicit representation of password argument
-     * to avoid ambiguity. For example string  "6161" can mean a string "6161" or 
+     * to avoid ambiguity. For example string  "6161" can mean a string "6161" or
      * a hexadecimal string of "aa" (i.e. \x61\x61).
      * @example
      * mac = KJUR.crypto.Mac({'alg': 'hmacsha256'});
@@ -900,7 +900,7 @@ KJUR.crypto.Mac = function(params) {
 
 	if (typeof pass != 'object')
 	    throw "KJUR.crypto.Mac unsupported password type: " + pass;
-	
+
 	var hPass = null;
 	if (pass.hex  !== undefined) {
 	    if (pass.hex.length % 2 != 0 || ! pass.hex.match(/^[0-9A-Fa-f]+$/))
@@ -993,7 +993,7 @@ KJUR.crypto.Mac = function(params) {
  * sig2.init(certPEM);
  * sig.updateString('aaa');
  * var isValid = sig2.verify(hSigVal);
- * 
+ *
  * // ECDSA signing
  * var sig = new KJUR.crypto.Signature({'alg':'SHA1withECDSA'});
  * sig.init(prvKeyPEM);
@@ -1066,7 +1066,7 @@ KJUR.crypto.Signature = function(params) {
 		throw "setAlgAndProvider hash alg set fail alg=" +
                     this.mdAlgName + "/" + ex;
 	    }
-	    
+
 	    this.init = function(keyparam, pass) {
 		var keyObj = null;
 		try {
@@ -1138,7 +1138,7 @@ KJUR.crypto.Signature = function(params) {
 		    return ec.verifyHex(this.sHashHex, hSigVal, this.ecpubhex);
 		} else if (this.pubKey instanceof RSAKey &&
 			   this.pubkeyAlgName == "rsaandmgf1") {
-		    return this.pubKey.verifyWithMessageHashPSS(this.sHashHex, hSigVal, 
+		    return this.pubKey.verifyWithMessageHashPSS(this.sHashHex, hSigVal,
 								this.mdAlgName,
 								this.pssSaltLen);
 		} else if (this.pubKey instanceof RSAKey &&
@@ -1334,7 +1334,7 @@ KJUR.crypto.Signature = function(params) {
  * <li>RSAOAEP512 - RSA/ECB/OAEPWithSHA-512AndMGF1Padding(*)</li>
  * </ul>
  * NOTE: (*) is not supported in Java JCE.<br/>
- * Currently this class supports only RSA encryption and decryption. 
+ * Currently this class supports only RSA encryption and decryption.
  * However it is planning to implement also symmetric ciphers near in the future.
  * @example
  */
@@ -1348,12 +1348,12 @@ KJUR.crypto.Cipher = function(params) {
  * @function
  * @param {String} s input string to encrypt
  * @param {Object} keyObj RSAKey object or hexadecimal string of symmetric cipher key
- * @param {String} algName short/long algorithm name for encryption/decryption 
+ * @param {String} algName short/long algorithm name for encryption/decryption
  * @return {String} hexadecimal encrypted string
  * @since jsrsasign 6.2.0 crypto 1.1.10
  * @description
  * This static method encrypts raw string with specified key and algorithm.
- * @example 
+ * @example
  * KJUR.crypto.Cipher.encrypt("aaa", pubRSAKeyObj) &rarr; "1abc2d..."
  * KJUR.crypto.Cipher.encrypt("aaa", pubRSAKeyObj, "RSAOAEP") &rarr; "23ab02..."
  */
@@ -1384,7 +1384,7 @@ KJUR.crypto.Cipher.encrypt = function(s, keyObj, algName) {
  * @since jsrsasign 6.2.0 crypto 1.1.10
  * @description
  * This static method decrypts encrypted hexadecimal string with specified key and algorithm.
- * @example 
+ * @example
  * KJUR.crypto.Cipher.decrypt("aaa", prvRSAKeyObj) &rarr; "1abc2d..."
  * KJUR.crypto.Cipher.decrypt("aaa", prvRSAKeyObj, "RSAOAEP) &rarr; "23ab02..."
  */
@@ -1423,7 +1423,7 @@ KJUR.crypto.Cipher.decrypt = function(hex, keyObj, algName) {
  * <li>RSAOAEP512 - RSA/ECB/OAEPWithSHA-512AndMGF1Padding(*)</li>
  * </ul>
  * NOTE: (*) is not supported in Java JCE.
- * @example 
+ * @example
  * KJUR.crypto.Cipher.getAlgByKeyAndName(objRSAKey) &rarr; "RSA"
  * KJUR.crypto.Cipher.getAlgByKeyAndName(objRSAKey, "RSAOAEP") &rarr; "RSAOAEP"
  */


### PR DESCRIPTION
1. The examples and parts of the documentation for `hextoArrayBuffer ` and `ArrayBuffertohex ` were inverted. 
2. For `KJUR.crypto.Mac` the examples use a variable instance named `mac`, but then some others use `md` (possible carryover from `KJUR.crypto.MessageDigest`)