### PR TITLE
Fixed readJWSJS to parse JSON objects properly

### DIFF
--- a/src/jwsjs-2.0.js
+++ b/src/jwsjs-2.0.js
@@ -261,7 +261,7 @@ KJUR.jws.JWSJS = function() {
 		    throw "malformed signatures";
 		}
 		if (spJWSJS.signatures.length > 0) {
-		    this.aSignatures = spJWSJS.signatures;
+		    this.aSignature = spJWSJS.signatures;
 		} else {
 		    throw "malformed signatures";
 		}


### PR DESCRIPTION
readJWSJS reads the signatures field of of the spJWSJS object into aSignatures instead of aSignature. This prevents verification after creating a JWSJS object using a JWS JSON object. Temporary workaround is to stringify the JSON object before calling readJWSJS.

Symptom: verifyAll and verifyNth fail to verify after a call to readJWSJS with a JSON object (or don't validate all signatures if multiple signatures exist). 