### PR TITLE
Fix for empty attribute values

### DIFF
--- a/src/asn1x509-1.0.js
+++ b/src/asn1x509-1.0.js
@@ -1504,8 +1504,10 @@ KJUR.asn1.x509.X500Name = function(params) {
         // Get all the dnObject attributes and stuff them in the ASN.1 array.
         for (var x in dnObj) {
             if (dnObj.hasOwnProperty(x)) {
-                var newRDN = new KJUR.asn1.x509.RDN(
-                    {'str': x + '=' + dnObj[x]});
+                const str = x + '=' + dnObj[x];
+                var newRDN = new KJUR.asn1.x509.RDN();
+                // Avoid parsing multi-valued strings
+                newRDN.addByString(str)
                 // Initialize or push into the ANS1 array.
                 this.asn1Array ? this.asn1Array.push(newRDN)
                     : this.asn1Array = [newRDN];
@@ -1795,7 +1797,7 @@ KJUR.asn1.x509.AttributeTypeAndValue = function(params) {
 	_KJUR_asn1 = _KJUR.asn1;
 
     this.setByString = function(attrTypeAndValueStr) {
-        var matchResult = attrTypeAndValueStr.match(/^([^=]+)=(.+)$/);
+        var matchResult = attrTypeAndValueStr.match(/^([^=]+)=(.*)$/);
         if (matchResult) {
             this.setByAttrTypeAndValueStr(matchResult[1], matchResult[2]);
         } else {


### PR DESCRIPTION
Per RFC 2253 attribute values can be empty:
```
attributeTypeAndValue = attributeType "=" attributeValue

attributeType = (ALPHA 1*keychar) / oid
keychar    = ALPHA / DIGIT / "-"

oid        = 1*DIGIT *("." 1*DIGIT)

attributeValue = string

string     = *( stringchar / pair )
             / "#" hexstring
             / QUOTATION *( quotechar / pair ) QUOTATION ; only from v2
```
where `*` is 0-or-more and `1*` is 1-or-more.

In addition to fixing the `AttributeTypeValue` regex, to allow creation of a `X500Name` by object with empty string value, I call `RDN.addByString` as opposed to using the constructor (which parses multi-valued RDN strings which `setByObject` would never get). 

This also addresses a breaking change introduced in 6.2.1 for values that have `+` in them: these suddenly got parsed as multi-value attributes.