### PR TITLE
sig -> var sig

### DIFF
--- a/src/asn1csr-1.0.js
+++ b/src/asn1csr-1.0.js
@@ -110,7 +110,7 @@ KJUR.asn1.csr.CertificationRequest = function(params) {
 	this.asn1SignatureAlg = 
 	    new _KJUR_asn1_x509.AlgorithmIdentifier({'name': sigAlgName});
 
-        sig = new _KJUR.crypto.Signature({'alg': sigAlgName});
+        var sig = new _KJUR.crypto.Signature({'alg': sigAlgName});
         sig.init(this.prvKey);
         sig.updateHex(this.asn1CSRInfo.getEncodedHex());
         this.hexSig = sig.sign();


### PR DESCRIPTION
Fixes "ReferenceError: assignment to undeclared variable sig"