### PR TITLE
Remove usage of deprecated RegExp method

### DIFF
--- a/src/rsasign-1.2.js
+++ b/src/rsasign-1.2.js
@@ -20,8 +20,7 @@
  * @license <a href="https://kjur.github.io/jsrsasign/license/">MIT License</a>
  */
 
-var _RE_HEXDECONLY = new RegExp("");
-_RE_HEXDECONLY.compile("[^0-9a-f]", "gi");
+var _RE_HEXDECONLY = new RegExp("[^0-9a-f]", "gi");
 
 // ========================================================================
 // Signature Generation


### PR DESCRIPTION
This PR removes the usage of the [deprecated method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/compile)  `RegExp.compile` and replaces it with the `RegExp` constructor. Running the library in an environment that does not support this method, such as in a React Native app with the [Hermes engine](https://facebook.github.io/react-native/docs/hermes) enabled, results in a crash.