### PR TITLE
Allow to specify alternative RSA public exponent

### DIFF
--- a/src/keyutil-1.0.js
+++ b/src/keyutil-1.0.js
@@ -1207,6 +1207,7 @@ KEYUTIL.getKey = function(param, passcode, hextype) {
  * @static
  * @param {String} alg 'RSA' or 'EC'
  * @param {Object} keylenOrCurve key length for RSA or curve name for EC
+ * @param {String} rsaPubExponent public exponent for RSA (default '10001')
  * @return {Array} associative array of keypair which has prvKeyObj and pubKeyObj parameters
  * @since keyutil 1.0.1
  * @description
@@ -1217,21 +1218,19 @@ KEYUTIL.getKey = function(param, passcode, hextype) {
  * <li>prvKeyObj - RSAKey or ECDSA object of private key</li>
  * <li>pubKeyObj - RSAKey or ECDSA object of public key</li>
  * </ul>
- * NOTE1: As for RSA algoirthm, public exponent has fixed
- * value '0x10001'.
- * NOTE2: As for EC algorithm, supported names of curve are
+ * NOTE1: As for EC algorithm, supported names of curve are
  * secp256r1, secp256k1 and secp384r1.
- * NOTE3: DSA is not supported yet.
+ * NOTE2: DSA is not supported yet.
  * @example
  * var rsaKeypair = KEYUTIL.generateKeypair("RSA", 1024);
  * var ecKeypair = KEYUTIL.generateKeypair("EC", "secp256r1");
  *
  */
-KEYUTIL.generateKeypair = function(alg, keylenOrCurve) {
+KEYUTIL.generateKeypair = function(alg, keylenOrCurve, rsaPubExponent = "10001") {
     if (alg == "RSA") {
         var keylen = keylenOrCurve;
         var prvKey = new RSAKey();
-        prvKey.generate(keylen, '10001');
+        prvKey.generate(keylen, rsaPubExponent);
         prvKey.isPrivate = true;
         prvKey.isPublic = true;
         


### PR DESCRIPTION
This PR allows to specify an alternative RSA exponent:

Sample code
```
#!/usr/bin/env node

jsrsasign = require('jsrsasign');
fs = require('fs');
const { exec } = require('child_process');

var key = jsrsasign.KEYUTIL.generateKeypair('RSA', 1024, "8020001");
var pem = jsrsasign.KEYUTIL.getPEM(key.prvKeyObj, 'PKCS1PRV');
console.log(pem);
fs.writeFileSync('key.pem', pem, 'utf-8');
```

Output key PEM:
``` 
-----BEGIN RSA PRIVATE KEY-----
MIICXAIBAAKBgQCiDI9LsH/YfPTBw7OInIFLrAbkwNXTWrHX3LHtczV5WuZFs+J9
BZvdEKkc47A3RXB2s7ghftTDzPnQtJ4Ew4XAg5o6MQjogyeKdsp/hvknEQRhQP3s
VJtWE3G5zzUldd7ziwnaN9hFDGBeps5tCJtO7rcy15FSo9KttPAiqU9KLwIECAIA
AQKBgDr0cOrwAfXxWrNEe2TKxZ3JBatl2KAUTFj1iV2GTCCQo7dObcaLcqQIjRk5
9Mu9zRB42JCha3exmlaxuVqp//xZxUN8/FzGI937NLNMZzORePI5VjfJ/dgA6956
0WP7HbgT3LSVRKZwMS9z/MTqnB3kb5Ie8LL9CwnvPkQWN76xAkEA4LI6id7Hsktc
orB2+UXBJR2y71mIbq4yo2lTRiEvAKTOKKcxyA86WNQvHkLVwAKyJh23rhuzRSKV
531pVrZHZQJBALigBqPekdlkTJX7N0/pJ3r4BJ4cGCZdFePQ9q2pP8+IOcGWDApk
ZcSwAq8pwsNDTep33xrPzd+93kPs4t4VZAMCQD0MJea62VeuzVXoUgZG2/ZRKOq5
ggjqTpwmGbYIf7zpd5Sl4X+JVz01riFgSwK00+MKZ5G0asl2EQcfGNBQH90CQAFo
R9r0nuQSZ3lMMkoN2LCFUT09EXqR4RniW/ktHpttFIIq2p02P7pH+MyyFNa4Uq8W
Fywo5RvaX/dH1imt4NECQA7xh4lCdIiSEgfglFxoXGb4oaBPArfHo/xfOX+/HBQP
ZX4F6KCgM5ty2ZXWLFZyYfsTAUHflJTdVvrRZyL1kJE=
-----END RSA PRIVATE KEY-----
```

Key as it is seen be OpenSSL:
```
> openssl rsa -in key.pem -noout -text
RSA Private-Key: (1024 bit, 2 primes)
modulus:
    00:a2:0c:8f:4b:b0:7f:d8:7c:f4:c1:c3:b3:88:9c:
    81:4b:ac:06:e4:c0:d5:d3:5a:b1:d7:dc:b1:ed:73:
    35:79:5a:e6:45:b3:e2:7d:05:9b:dd:10:a9:1c:e3:
    b0:37:45:70:76:b3:b8:21:7e:d4:c3:cc:f9:d0:b4:
    9e:04:c3:85:c0:83:9a:3a:31:08:e8:83:27:8a:76:
    ca:7f:86:f9:27:11:04:61:40:fd:ec:54:9b:56:13:
    71:b9:cf:35:25:75:de:f3:8b:09:da:37:d8:45:0c:
    60:5e:a6:ce:6d:08:9b:4e:ee:b7:32:d7:91:52:a3:
    d2:ad:b4:f0:22:a9:4f:4a:2f
publicExponent: 134348801 (0x8020001)
privateExponent:
    3a:f4:70:ea:f0:01:f5:f1:5a:b3:44:7b:64:ca:c5:
    9d:c9:05:ab:65:d8:a0:14:4c:58:f5:89:5d:86:4c:
    20:90:a3:b7:4e:6d:c6:8b:72:a4:08:8d:19:39:f4:
    cb:bd:cd:10:78:d8:90:a1:6b:77:b1:9a:56:b1:b9:
    5a:a9:ff:fc:59:c5:43:7c:fc:5c:c6:23:dd:fb:34:
    b3:4c:67:33:91:78:f2:39:56:37:c9:fd:d8:00:eb:
    de:7a:d1:63:fb:1d:b8:13:dc:b4:95:44:a6:70:31:
    2f:73:fc:c4:ea:9c:1d:e4:6f:92:1e:f0:b2:fd:0b:
    09:ef:3e:44:16:37:be:b1
prime1:
    00:e0:b2:3a:89:de:c7:b2:4b:5c:a2:b0:76:f9:45:
    c1:25:1d:b2:ef:59:88:6e:ae:32:a3:69:53:46:21:
    2f:00:a4:ce:28:a7:31:c8:0f:3a:58:d4:2f:1e:42:
    d5:c0:02:b2:26:1d:b7:ae:1b:b3:45:22:95:e7:7d:
    69:56:b6:47:65
prime2:
    00:b8:a0:06:a3:de:91:d9:64:4c:95:fb:37:4f:e9:
    27:7a:f8:04:9e:1c:18:26:5d:15:e3:d0:f6:ad:a9:
    3f:cf:88:39:c1:96:0c:0a:64:65:c4:b0:02:af:29:
    c2:c3:43:4d:ea:77:df:1a:cf:cd:df:bd:de:43:ec:
    e2:de:15:64:03
exponent1:
    3d:0c:25:e6:ba:d9:57:ae:cd:55:e8:52:06:46:db:
    f6:51:28:ea:b9:82:08:ea:4e:9c:26:19:b6:08:7f:
    bc:e9:77:94:a5:e1:7f:89:57:3d:35:ae:21:60:4b:
    02:b4:d3:e3:0a:67:91:b4:6a:c9:76:11:07:1f:18:
    d0:50:1f:dd
exponent2:
    01:68:47:da:f4:9e:e4:12:67:79:4c:32:4a:0d:d8:
    b0:85:51:3d:3d:11:7a:91:e1:19:e2:5b:f9:2d:1e:
    9b:6d:14:82:2a:da:9d:36:3f:ba:47:f8:cc:b2:14:
    d6:b8:52:af:16:17:2c:28:e5:1b:da:5f:f7:47:d6:
    29:ad:e0:d1
coefficient:
    0e:f1:87:89:42:74:88:92:12:07:e0:94:5c:68:5c:
    66:f8:a1:a0:4f:02:b7:c7:a3:fc:5f:39:7f:bf:1c:
    14:0f:65:7e:05:e8:a0:a0:33:9b:72:d9:95:d6:2c:
    56:72:61:fb:13:01:41:df:94:94:dd:56:fa:d1:67:
    22:f5:90:91
```

Test with OpenSSL (1.1.1d):
```
var cert = new jsrsasign.KJUR.asn1.x509.Certificate({
 version: 3,
 serial: {hex: "010203"},
 sigalg: "SHA256withRSA",
 issuer: {str: "/CN=User1"},
 notbefore: "011231235959Z",
 notafter:  "221231235959Z",
 subject: {str: "/CN=User1"},
 sbjpubkey: pem,
 ext: [
  {extname: "keyUsage", names:["digitalSignature", "keyCertSign"], critical:true},
  {extname: "basicConstraints", cA:true, critical:true},
  {extname: "subjectAltName", array:[{"rfc822": "user1@example.com"}]},
  {extname: "cRLDistributionPoints", array:[{fulluri:"https://example.com/ca1.crl"}]}
 ],
 cakey: pem
});
console.log(`cert: ${cert.getPEM()}`);
fs.writeFileSync('cert.pem', cert.getPEM(), 'utf-8');
```

Output certificate PEM:
```
-----BEGIN CERTIFICATE-----
MIICCDCCAXGgAwIBAgIDAQIDMA0GCSqGSIb3DQEBCwUAMBAxDjAMBgNVBAMMBVVz
ZXIxMB4XDTAxMTIzMTIzNTk1OVoXDTIyMTIzMTIzNTk1OVowEDEOMAwGA1UEAwwF
VXNlcjEwgaAwDQYJKoZIhvcNAQEBBQADgY4AMIGKAoGBAKIMj0uwf9h89MHDs4ic
gUusBuTA1dNasdfcse1zNXla5kWz4n0Fm90QqRzjsDdFcHazuCF+1MPM+dC0ngTD
hcCDmjoxCOiDJ4p2yn+G+ScRBGFA/exUm1YTcbnPNSV13vOLCdo32EUMYF6mzm0I
m07utzLXkVKj0q208CKpT0ovAgQIAgABo28wbTAOBgNVHQ8BAf8EBAMCAoQwDwYD
VR0TAQH/BAUwAwEB/zAcBgNVHREEFTATgRF1c2VyMUBleGFtcGxlLmNvbTAsBgNV
HR8EJTAjMCGgH6AdhhtodHRwczovL2V4YW1wbGUuY29tL2NhMS5jcmwwDQYJKoZI
hvcNAQELBQADgYEACOE7JcD3RU5UGN2z3tnhLn+nSykRNjFKU6+EY01dUz2GTUsq
pLWNxcSgDcKGBoOl+JYVZiRjZgYvzO7Lfk7RhFXyXi42aHhdhLO+pACrqUSPqBhE
NPlD350/L00fZgOCEnxxJlIF2QW/OYUo+ZipuF5g+lAB7oEizLThjEwo1Bs=
-----END CERTIFICATE-----
```

Check with OpenSSL:
```
> openssl x509 -in cert.pem -noout -text
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 66051 (0x10203)
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: CN = User1
        Validity
            Not Before: Dec 31 23:59:59 2001 GMT
            Not After : Dec 31 23:59:59 2022 GMT
        Subject: CN = User1
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
                RSA Public-Key: (1024 bit)
                Modulus:
                    00:a2:0c:8f:4b:b0:7f:d8:7c:f4:c1:c3:b3:88:9c:
                    81:4b:ac:06:e4:c0:d5:d3:5a:b1:d7:dc:b1:ed:73:
                    35:79:5a:e6:45:b3:e2:7d:05:9b:dd:10:a9:1c:e3:
                    b0:37:45:70:76:b3:b8:21:7e:d4:c3:cc:f9:d0:b4:
                    9e:04:c3:85:c0:83:9a:3a:31:08:e8:83:27:8a:76:
                    ca:7f:86:f9:27:11:04:61:40:fd:ec:54:9b:56:13:
                    71:b9:cf:35:25:75:de:f3:8b:09:da:37:d8:45:0c:
                    60:5e:a6:ce:6d:08:9b:4e:ee:b7:32:d7:91:52:a3:
                    d2:ad:b4:f0:22:a9:4f:4a:2f
                Exponent: 134348801 (0x8020001)
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Certificate Sign
            X509v3 Basic Constraints: critical
                CA:TRUE
            X509v3 Subject Alternative Name: 
                email:user1@example.com
            X509v3 CRL Distribution Points: 

                Full Name:
                  URI:https://example.com/ca1.crl

    Signature Algorithm: sha256WithRSAEncryption
         08:e1:3b:25:c0:f7:45:4e:54:18:dd:b3:de:d9:e1:2e:7f:a7:
         4b:29:11:36:31:4a:53:af:84:63:4d:5d:53:3d:86:4d:4b:2a:
         a4:b5:8d:c5:c4:a0:0d:c2:86:06:83:a5:f8:96:15:66:24:63:
         66:06:2f:cc:ee:cb:7e:4e:d1:84:55:f2:5e:2e:36:68:78:5d:
         84:b3:be:a4:00:ab:a9:44:8f:a8:18:44:34:f9:43:df:9d:3f:
         2f:4d:1f:66:03:82:12:7c:71:26:52:05:d9:05:bf:39:85:28:
         f9:98:a9:b8:5e:60:fa:50:01:ee:81:22:cc:b4:e1:8c:4c:28:
         d4:1b
```

Signature verification:
```
openssl verify -CAfile cert.pem -check_ss_sig cert.pem
cert.pem: OK
```
