### PR TITLE
Add support for secp256k1

### DIFF
--- a/src/ecdsa-modified-1.0.js
+++ b/src/ecdsa-modified-1.0.js
@@ -165,6 +165,8 @@ KJUR.crypto.ECDSA = function(params) {
 	    return "P-384";
 	if (s === "secp521r1" || s === "NIST P-521" || s === "P-521")
 	    return "P-521";
+	if (s === "secp256k1")
+		return "secp256k1";
 	return null;
     };
 

--- a/src/keyutil-1.0.js
+++ b/src/keyutil-1.0.js
@@ -1862,7 +1862,7 @@ KEYUTIL.getJWK = function(keyinfo, nokid, nox5c, nox5t, nox5t2) {
 	jwk.e = hextob64u(keyObj.e.toString(16));
     } else if (keyObj instanceof KJUR.crypto.ECDSA && keyObj.isPrivate) {
 	var name = keyObj.getShortNISTPCurveName();
-	if (name !== "P-256" && name !== "P-384" && name !== "P-521")
+	if (name !== "P-256" && name !== "P-384" && name !== "P-521" && name !== "secp256k1")
 	    throw new Error("unsupported curve name for JWT: " + name);
 	var xy = keyObj.getPublicKeyXYHex();
 	jwk.kty = "EC";
@@ -1872,7 +1872,7 @@ KEYUTIL.getJWK = function(keyinfo, nokid, nox5c, nox5t, nox5t2) {
 	jwk.d = hextob64u(keyObj.prvKeyHex);
     } else if (keyObj instanceof KJUR.crypto.ECDSA && keyObj.isPublic) {
 	var name = keyObj.getShortNISTPCurveName();
-	if (name !== "P-256" && name !== "P-384" && name !== "P-521")
+	if (name !== "P-256" && name !== "P-384" && name !== "P-521" && name !== "secp256k1")
 	    throw new Error("unsupported curve name for JWT: " + name);
 	var xy = keyObj.getPublicKeyXYHex();
 	jwk.kty = "EC";

--- a/test/qunit-do-ecdsamod.html
+++ b/test/qunit-do-ecdsamod.html
@@ -287,7 +287,7 @@ test("getShortNISTPCurveName() method test", function() {
   ec1 = new KJUR.crypto.ECDSA({'curve': 'secp521r1', 'pub': ECK1PUBHEX});
   equal(ec1.getShortNISTPCurveName(), "P-521", "secp521r1 - P-521");
   ec1 = new KJUR.crypto.ECDSA({'curve': 'secp256k1', 'pub': ECK1PUBHEX});
-  equal(ec1.getShortNISTPCurveName(), null, "secp256k1 - null");
+  equal(ec1.getShortNISTPCurveName(), "secp256k1", "secp256k1 - null");
 });
 
 test("readPKCS5PrvKeyHex k1", function() {

--- a/test/qunit-do-keyutil-jwk.html
+++ b/test/qunit-do-keyutil-jwk.html
@@ -92,6 +92,26 @@ var prvEC1 =
   "use" : "enc",
   "kid" : "1"
 };
+// Arbitrary test data for secp256k1
+var pubsecp256k1 = 
+{
+  "kty" : "EC",
+  "crv" : "secp256k1",
+  "x" : "ETkUVhg6-xtkT_JL6KAFjw3ZB26ZtVQhpAE871EpVm4",
+  "y" : "kTKkieii1A4UCAmZHT1us1Eq_mLX1FUonGRLCpfo-YQ",
+  "use" : "enc",
+  "kid" : "1"
+}
+var prvsecp256k1 = 
+{
+  "kty" : "EC",
+  "crv" : "secp256k1",
+  "x" : "ETkUVhg6-xtkT_JL6KAFjw3ZB26ZtVQhpAE871EpVm4",
+  "y" : "kTKkieii1A4UCAmZHT1us1Eq_mLX1FUonGRLCpfo-YQ",
+  "d" : "cdsLOXwL9pUNlwVbigl2UYBwHOtRVCn9N0AmHHr-IA0",
+  "use" : "enc",
+  "kid" : "1"
+};
 // RFC7517 A.2.2 RSA PRV
 var prvRSA1 =
 { "kty" : "RSA",
@@ -332,6 +352,32 @@ var expected = {
     d: "870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE",
 };
 deepEqual(jwk, expected, "EC P-256");
+});
+
+test("getJWK() - public EC secp256k1", function() {
+var ec = KEYUTIL.getKey(pubsecp256k1);
+var jwk = KEYUTIL.getJWK(ec);
+var expected = {
+    kty: "EC",
+    crv: "secp256k1",
+    x : "ETkUVhg6-xtkT_JL6KAFjw3ZB26ZtVQhpAE871EpVm4",
+    y : "kTKkieii1A4UCAmZHT1us1Eq_mLX1FUonGRLCpfo-YQ",
+    kid: "y_68HYcuzVEv4WsG5AElS1p4JUOp7jZDgrlrZXjmEWM"
+};
+deepEqual(jwk, expected, "EC secp256k1");
+});
+
+test("getJWK() - private EC secp256k1", function() {
+var ec = KEYUTIL.getKey(prvsecp256k1);
+var jwk = KEYUTIL.getJWK(ec);
+var expected = {
+    kty: "EC",
+    crv: "secp256k1",
+    x : "ETkUVhg6-xtkT_JL6KAFjw3ZB26ZtVQhpAE871EpVm4",
+    y : "kTKkieii1A4UCAmZHT1us1Eq_mLX1FUonGRLCpfo-YQ",
+    d : "cdsLOXwL9pUNlwVbigl2UYBwHOtRVCn9N0AmHHr-IA0"
+};
+deepEqual(jwk, expected, "EC secp256k1");
 });
 
 test("getJWK() - public EC P-521", function() {


### PR DESCRIPTION
I noticed that `secp256k1` wasn't supported when running `getJWK` which returned: `Error: unsupported curve name for JWT: null`.

This PR should fix this, along with updates for relevant unit tests.

