### PR TITLE
Fix error loading library in Postman

### DIFF
--- a/ext/rng.js
+++ b/ext/rng.js
@@ -29,7 +29,7 @@ if (rng_pool == null) {
   rng_pool = new Array();
   rng_pptr = 0;
   var t;
-  if (window !== undefined &&
+  if (typeof window !== "undefined" &&
       (window.crypto !== undefined ||
        window.msCrypto !== undefined)) {
     var crypto = window.crypto || window.msCrypto;


### PR DESCRIPTION
Loading the library in Postman test scripts throws an error because `window` is not defined. Fixed how definition of `window` is checked.