### PR TITLE
Fix #221: ecdsa-modified: fix bias and omission of zero in getBigRandom()

### DIFF
--- a/src/ecdsa-modified-1.0.js
+++ b/src/ecdsa-modified-1.0.js
@@ -95,11 +95,15 @@ KJUR.crypto.ECDSA = function(params) {
     //===========================
     // PUBLIC METHODS
     //===========================
+    /*
+     * Generate uniformly distributed big random integer in 0 <= x < limit
+     */
     this.getBigRandom = function (limit) {
-	return new _BigInteger(limit.bitLength(), rng)
-	.mod(limit.subtract(_BigInteger.ONE))
-	.add(_BigInteger.ONE)
-	;
+        var bitLength = limit.subtract(_BigInteger.ONE).bitLength();
+        do {
+            var result = new _BigInteger(bitLength, rng);
+        } while (result.compareTo(limit) >= 0);
+        return result;
     };
 
     this.setNamedCurve = function(curveName) {


### PR DESCRIPTION
I have evaluated the simple filtering approach and the approach from https://github.com/swiftlang/swift/pull/39143 and found out that the former is a lot more performant than (my adaption of) the latter and still effective for fixing issue https://github.com/kjur/jsrsasign/issues/221 .

See https://htmlpreview.github.io/?https://github.com/tvogel/jsrsasign/blob/tv/getBigRandom-comparison/src/ecdsamod-new-random.output.html for a comparison of the functions. The histograms also make the problem from #221 evident.

In most cases, the new function is faster than the previous implementation and only rarely slightly slower.

The main advantage for the dismissed alternative `new2` would be that it is constant in time (depending on the limit only) but it involves consuming always exactly two big random numbers and two big multiplications.

See https://github.com/tvogel/jsrsasign/blob/tv/getBigRandom-comparison/src/ecdsamod-new-random.html for the benchmarking code.

