### PR TITLE
Fix instanceof check for params array

### DIFF
--- a/src/asn1tsp-1.0.js
+++ b/src/asn1tsp-1.0.js
@@ -777,7 +777,7 @@ KJUR.asn1.tsp.PKIFreeText = function(params) {
     this.tohex = function() {
 	var params = this.params;
 
-	if (! params instanceof Array)
+	if (! (params instanceof Array))
 	    throw new _Error("wrong params: not array");
 
 	var a = [];


### PR DESCRIPTION
Fixed "suspicious-boolean-not" suggested by esbuild. 
While building my project I got a warning on this library so I thought I'd help. 
You can check why this is a problem  in this jsfiddle https://jsfiddle.net/t564uxpo/ or by running this code:
```
var tests = [[],"string",1,{}];
for(var i=0; i<4; i++){
  var test = tests[i];
  console.log("testing: " + JSON.stringify(test));
  if(!(test instanceof Array))
    console.log("Not Array")
  else
    console.log("Array");

  if(! test instanceof Array)
    console.log("Not Array")
  else
    console.log("Array");
}
```
Only with the parenthesis you get the desired behaviour