### PR TITLE
fix: reject non-shortest DER lengths

### DIFF
--- a/src/asn1hex-1.1.js
+++ b/src/asn1hex-1.1.js
@@ -1279,13 +1279,15 @@ ASN1HEX.checkStrictDER = function(h, idx, maxHexLen, maxByteLen, maxLbyteLen) {
 	if (maxByteLen < 0x80) {
 	    maxLbyteLen = 1;
 	} else {
-	    maxLbyteLen = Math.ceil(maxByteLen.toString(16)) + 1;
+	    maxLbyteLen = Math.ceil(maxByteLen.toString(16).length / 2) + 1;
 	}
     }
     //console.log(maxHexLen + ":" + maxByteLen + ":" + maxLbyteLen);
 
     // 3. check if L(length) string not exceeds maxLbyteLen
     var hL = _ASN1HEX.getL(h, idx);
+    if (hL === "")
+	throw new Error("malformed L of TLV: idx=" + idx);
     if (hL.length > maxLbyteLen * 2)
 	throw new Error("L of TLV too long: idx=" + idx);
 
@@ -1294,6 +1296,18 @@ ASN1HEX.checkStrictDER = function(h, idx, maxHexLen, maxByteLen, maxLbyteLen) {
     var vblen = _ASN1HEX.getVblen(h, idx);
     if (vblen > maxByteLen) 
 	throw new Error("value of L too long than hex: idx=" + idx);
+
+    // 4a. DER requires shortest length encoding.
+    if (hL.length > 2) {
+	var hLenValue = hL.substr(2);
+	if (vblen < 128)
+	    throw new Error("not shortest length encoding: idx=" + idx);
+	if (hLenValue.substr(0, 2) === "00")
+	    throw new Error("leading zero in L of TLV: idx=" + idx);
+	var minLbyteLen = Math.ceil(vblen.toString(16).length / 2) + 1;
+	if ((hL.length / 2) > minLbyteLen)
+	    throw new Error("L of TLV too long: idx=" + idx);
+    }
 
     // 5. check V string length and L's value are the same
     var hTLV = _ASN1HEX.getTLV(h, idx);

--- a/test/qunit-do-ecdsamod-s.html
+++ b/test/qunit-do-ecdsamod-s.html
@@ -118,6 +118,22 @@ for (const curve in SIGNATURES) {
   });
 }
 
+test("P-521 strict DER rejects non-shortest length encodings", function() {
+  const sig = SIGNATURES["P-521"][0].asn1;
+  const r = sig.substr(10, 130);
+  const s = sig.substr(144, 130);
+
+  equal(ASN1HEX.checkStrictDER(sig, 0, sig.length / 2), undefined, "valid P-521 signature accepted");
+
+  throws(function() {
+    ASN1HEX.checkStrictDER("30820086" + sig.substr(6), 0, sig.length / 2 + 2);
+  }, Error, "sequence length with a leading zero is rejected");
+
+  throws(function() {
+    ASN1HEX.checkStrictDER("308187028141" + r + "0241" + s, 0, sig.length / 2 + 1);
+  }, Error, "integer length in unnecessary long form is rejected");
+});
+
 });
 </script>
   


### PR DESCRIPTION
Fixes #658.

This tightens strict DER length validation so P-521 ECDSA signatures with non-minimal length encodings are rejected instead of being accepted by `checkStrictDER`.

Changes:
- calculate the maximum length-of-length byte count from the byte length correctly
- reject empty, leading-zero, and non-shortest long-form DER length encodings
- add P-521 regression coverage for the invalid length forms

Validation:
- `node /tmp/check_jsrsasign_der.js`
- `git diff --check -- src/asn1hex-1.1.js test/qunit-do-ecdsamod-s.html`
